### PR TITLE
Fix dict access error

### DIFF
--- a/simpletransformers/model.py
+++ b/simpletransformers/model.py
@@ -211,8 +211,8 @@ class TransformerModel:
                 inputs = {'input_ids':      batch[0],
                           'attention_mask': batch[1],
                           'labels':         batch[3]}
-                if args.model_type != 'distilbert':
-                    inputs['token_type_ids'] = batch[2] if args.model_type in ['bert', 'xlnet'] else None  # XLM, DistilBERT and RoBERTa don't use segment_ids
+                if args['model_type'] != 'distilbert':
+                    inputs['token_type_ids'] = batch[2] if args['model_type'] in ['bert', 'xlnet'] else None  # XLM, DistilBERT and RoBERTa don't use segment_ids
                 outputs = model(**inputs)
                 tmp_eval_loss, logits = outputs[:2]
 
@@ -344,8 +344,8 @@ class TransformerModel:
                         'attention_mask': batch[1],
                         'labels':         batch[3]}
                 # XLM, DistilBERT and RoBERTa don't use segment_ids
-                if args.model_type != 'distilbert':
-                    inputs['token_type_ids'] = batch[2] if args.model_type in ['bert', 'xlnet'] else None  
+                if args['model_type'] != 'distilbert':
+                    inputs['token_type_ids'] = batch[2] if args['model_type'] in ['bert', 'xlnet'] else None  
                 outputs = model(**inputs)
                 # model outputs are always tuple in pytorch-transformers (see doc)
                 loss = outputs[0]


### PR DESCRIPTION
Accessing the `args` dictionary with dot notation gives an error in version 0.3.8, so I replaced it with braces.