### PR TITLE
Fix tqdm printing for python notebooks

### DIFF
--- a/simpletransformers/model.py
+++ b/simpletransformers/model.py
@@ -17,7 +17,7 @@ import numpy as np
 from scipy.stats import pearsonr
 from sklearn.metrics import mean_squared_error, matthews_corrcoef, confusion_matrix
 from tensorboardX import SummaryWriter
-from tqdm import trange, tqdm
+from tqdm.auto import trange, tqdm
 
 from torch.utils.data.distributed import DistributedSampler
 from torch.utils.data import (


### PR DESCRIPTION
Using `simpletransformers` in a python notebook results into excessive printing due to `tqdm`. `tqdm` has a mode specifically for notebooks and a method of importing to detect whether it's operating in a notebook or not by importing from `tqdm.auto` instead of `tqdm` (see https://github.com/tqdm/tqdm#ipythonjupyter-integration).

### Current output in notebooks (many lines per epoch)

![tqdm notebook](https://user-images.githubusercontent.com/12242351/67251966-02498380-f43f-11e9-8de7-a7972b7bcc38.png)

### Output in notebooks after this change (one line per epoch)
![image](https://user-images.githubusercontent.com/12242351/67251898-ab43ae80-f43e-11e9-9dbc-193f92909360.png)
 