### PR TITLE
Camembert support for NERModel and disabled multiprocessing for example preparation ( ) 

### DIFF
--- a/simpletransformers/ner/ner_model.py
+++ b/simpletransformers/ner/ner_model.py
@@ -35,7 +35,7 @@ except ImportError:
 
 
 from simpletransformers.ner.ner_utils import InputExample, convert_examples_to_features, get_labels, read_examples_from_file, get_examples_from_df
-
+from transformers import CamembertConfig, CamembertForTokenClassification, CamembertTokenizer
 
 class NERModel:
     def __init__(self, model_type, model_name, labels=None, args=None, use_cuda=True):
@@ -59,11 +59,13 @@ class NERModel:
         if roberta_available:
             MODEL_CLASSES = {
                 'bert': (BertConfig, BertForTokenClassification, BertTokenizer),
-                'roberta': (RobertaConfig, RobertaForTokenClassification, RobertaTokenizer)
+                'roberta': (RobertaConfig, RobertaForTokenClassification, RobertaTokenizer),
+                'camembert': (CamembertConfig, CamembertForTokenClassification, CamembertTokenizer)
             }
         else:
             MODEL_CLASSES = {
                 'bert': (BertConfig, BertForTokenClassification, BertTokenizer),
+                
             }
 
         config_class, model_class, tokenizer_class = MODEL_CLASSES[model_type]

--- a/simpletransformers/ner/ner_model.py
+++ b/simpletransformers/ner/ner_model.py
@@ -4,6 +4,7 @@ import os
 import math
 import json
 import random
+import warnings
 
 from multiprocessing import cpu_count
 
@@ -26,6 +27,8 @@ from torch.utils.data import (
 
 from transformers import AdamW, get_linear_schedule_with_warmup
 from transformers import WEIGHTS_NAME, BertConfig, BertForTokenClassification, BertTokenizer
+from transformers import CamembertConfig, CamembertForTokenClassification, CamembertTokenizer
+
 try:
     from transformers import RobertaConfig, RobertaForTokenClassification, RobertaTokenizer
     roberta_available = True
@@ -35,7 +38,7 @@ except ImportError:
 
 
 from simpletransformers.ner.ner_utils import InputExample, convert_examples_to_features, get_labels, read_examples_from_file, get_examples_from_df
-from transformers import CamembertConfig, CamembertForTokenClassification, CamembertTokenizer
+
 
 class NERModel:
     def __init__(self, model_type, model_name, labels=None, args=None, use_cuda=True):
@@ -65,7 +68,7 @@ class NERModel:
         else:
             MODEL_CLASSES = {
                 'bert': (BertConfig, BertForTokenClassification, BertTokenizer),
-                
+                'camembert': (CamembertConfig, CamembertForTokenClassification, CamembertTokenizer)
             }
 
         config_class, model_class, tokenizer_class = MODEL_CLASSES[model_type]
@@ -121,6 +124,10 @@ class NERModel:
 
         self.args['model_name'] = model_name
         self.args['model_type'] = model_type
+
+        if model_type == 'camembert':
+            warnings.warn("use_multiprocessing automatically disabled as CamemBERT fails when using multiprocessing for feature conversion.")
+            self.args['use_multiprocessing'] = False
 
         self.pad_token_label_id = CrossEntropyLoss().ignore_index
 

--- a/simpletransformers/ner/ner_utils.py
+++ b/simpletransformers/ner/ner_utils.py
@@ -87,7 +87,6 @@ def get_examples_from_df(data):
 
 
 def convert_example_to_feature(example_row):
-
     example, label_map, max_seq_length, tokenizer, cls_token_at_end, cls_token, cls_token_segment_id, sep_token, sep_token_extra, pad_on_left, pad_token, pad_token_segment_id, pad_token_label_id, sequence_a_segment_id, mask_padding_with_zero = example_row
 
     tokens = []
@@ -217,10 +216,9 @@ def convert_examples_to_features(
         mask_padding_with_zero)
         
             for example in examples]
-
-    with Pool(process_count) as p:
-        features = list(tqdm(p.imap(convert_example_to_feature, examples, chunksize=chunksize), total=len(examples), disable=silent))
-
+    features = []
+    for example in tqdm(examples):
+        features.append(convert_example_to_feature(example))
     return features
 
 

--- a/simpletransformers/ner/ner_utils.py
+++ b/simpletransformers/ner/ner_utils.py
@@ -87,6 +87,7 @@ def get_examples_from_df(data):
 
 
 def convert_example_to_feature(example_row):
+
     example, label_map, max_seq_length, tokenizer, cls_token_at_end, cls_token, cls_token_segment_id, sep_token, sep_token_extra, pad_on_left, pad_token, pad_token_segment_id, pad_token_label_id, sequence_a_segment_id, mask_padding_with_zero = example_row
 
     tokens = []
@@ -216,9 +217,10 @@ def convert_examples_to_features(
         mask_padding_with_zero)
         
             for example in examples]
-    features = []
-    for example in tqdm(examples):
-        features.append(convert_example_to_feature(example))
+
+    with Pool(process_count) as p:
+        features = list(tqdm(p.imap(convert_example_to_feature, examples, chunksize=chunksize), total=len(examples), disable=silent))
+
     return features
 
 


### PR DESCRIPTION
Hello,

I had to disable multiprocessing for example preparation because of the following Error:
TypeError: can't pickle SwigPyObject objects

Also added support for Camembert new model

Feel free to edit it; Do not hesitate if you have any question

Antoine