### PR TITLE
No save every epoch

### DIFF
--- a/README.md
+++ b/README.md
@@ -829,6 +829,7 @@ self.args = {
   'evaluate_during_training_steps': 2000,
   `save_eval_checkpoints`: True
   'save_steps': 2000,
+  'save_model_every_epoch': False,
   'tensorboard_dir': None,
 
   'overwrite_output_dir': False,
@@ -901,6 +902,9 @@ Log training loss and learning at every specified number of steps.
 
 #### *save_steps: int*
 Save a model checkpoint at every specified number of steps.
+
+#### *save_model_every_epoch: bool*
+Save a model at the end of every epoch.
 
 #### *tensorboard_dir: str*
 The directory where Tensorboard events will be stored during training. By default, Tensorboard events will be saved in a subfolder inside `runs/`  like `runs/Dec02_09-32-58_36d9e58955b0/`.

--- a/simpletransformers/classification/classification_model.py
+++ b/simpletransformers/classification/classification_model.py
@@ -134,6 +134,7 @@ class ClassificationModel:
 
             'logging_steps': 50,
             'save_steps': 2000,
+            'save_model_every_epoch': False,
             'evaluate_during_training': False,
             'evaluate_during_training_steps': 2000,
             'save_eval_checkpoints': True,
@@ -401,12 +402,13 @@ class ClassificationModel:
             epoch_number += 1
             output_dir_current = os.path.join(output_dir, "epoch-{}".format(epoch_number))
 
-            if not os.path.exists(output_dir_current):
+            if (args['save_model_every_epoch'] or args['evaluate_during_training']) and not os.path.exists(output_dir_current):
                 os.makedirs(output_dir_current)
 
-            model_to_save = model.module if hasattr(model, "module") else model
-            model_to_save.save_pretrained(output_dir_current)
-            self.tokenizer.save_pretrained(output_dir_current)
+            if args['save_model_every_epoch']:
+                model_to_save = model.module if hasattr(model, "module") else model
+                model_to_save.save_pretrained(output_dir_current)
+                self.tokenizer.save_pretrained(output_dir_current)
 
             if args['evaluate_during_training']:
                 results, _, _ = self.eval_model(eval_df, verbose=True, **kwargs)


### PR DESCRIPTION
This pull requests reduce the amount of disk used during training. From what I see in the code, a change merged late December introduced saving every epoch. In our case, the Sagemaker instance filled its 50GB disk during training.

We might not be the only ones struggling with disk space during training so I set the default value of the flag to false.