### PR TITLE
Fix ClassificationModel constructor when args is None

### DIFF
--- a/simpletransformers/classification/classification_model.py
+++ b/simpletransformers/classification/classification_model.py
@@ -99,7 +99,7 @@ class ClassificationModel:
             "xlmroberta": (XLMRobertaConfig, XLMRobertaForSequenceClassification, XLMRobertaTokenizer),
         }
 
-        if 'manual_seed' in args:
+        if args and 'manual_seed' in args:
             random.seed(args['manual_seed'])
             np.random.seed(args['manual_seed'])
             torch.manual_seed(args['manual_seed'])


### PR DESCRIPTION
The ClassificationModel constructor breaks when the default value for the `args` argument is set to `None` by default.