### PR TITLE
Set the default encoding as "utf-8" on QA model module

### DIFF
--- a/simpletransformers/config/global_args.py
+++ b/simpletransformers/config/global_args.py
@@ -43,4 +43,5 @@ global_args = {
     "early_stopping_metric": "eval_loss",
     "early_stopping_metric_minimize": True,
     "manual_seed": None,
+    "encoding": None,
 }

--- a/simpletransformers/question_answering/question_answering_model.py
+++ b/simpletransformers/question_answering/question_answering_model.py
@@ -255,7 +255,7 @@ class QuestionAnsweringModel:
         self._move_model_to_device()
 
         if isinstance(train_data, str):
-            with open(train_data, "r", encoding="utf-8") as f:
+            with open(train_data, "r", encoding=self.args["encoding"]) as f:
                 train_examples = json.load(f)
         else:
             train_examples = train_data
@@ -526,7 +526,7 @@ class QuestionAnsweringModel:
         all_predictions, all_nbest_json, scores_diff_json = self.evaluate(eval_data, output_dir)
 
         if isinstance(eval_data, str):
-            with open(eval_data, "r", encoding="utf-8") as f:
+            with open(eval_data, "r", encoding=self.args["encoding"]) as f:
                 truth = json.load(f)
         else:
             truth = eval_data
@@ -552,7 +552,7 @@ class QuestionAnsweringModel:
         args = self.args
 
         if isinstance(eval_data, str):
-            with open(eval_data, "r", encoding="utf-8") as f:
+            with open(eval_data, "r", encoding=self.args["encoding"]) as f:
                 eval_examples = json.load(f)
         else:
             eval_examples = eval_data

--- a/simpletransformers/question_answering/question_answering_model.py
+++ b/simpletransformers/question_answering/question_answering_model.py
@@ -255,7 +255,7 @@ class QuestionAnsweringModel:
         self._move_model_to_device()
 
         if isinstance(train_data, str):
-            with open(train_data, "r") as f:
+            with open(train_data, "r", encoding="utf-8") as f:
                 train_examples = json.load(f)
         else:
             train_examples = train_data
@@ -526,7 +526,7 @@ class QuestionAnsweringModel:
         all_predictions, all_nbest_json, scores_diff_json = self.evaluate(eval_data, output_dir)
 
         if isinstance(eval_data, str):
-            with open(eval_data, "r") as f:
+            with open(eval_data, "r", encoding="utf-8") as f:
                 truth = json.load(f)
         else:
             truth = eval_data
@@ -552,7 +552,7 @@ class QuestionAnsweringModel:
         args = self.args
 
         if isinstance(eval_data, str):
-            with open(eval_data, "r") as f:
+            with open(eval_data, "r", encoding="utf-8") as f:
                 eval_examples = json.load(f)
         else:
             eval_examples = eval_data


### PR DESCRIPTION
Give a default encoding as "utf-8" can avoid using "cp950" encoding on windows, which may occur an error while reading a json file with Chinese characters.