### PR TITLE
Initialize the variable 'feature' from the variable 'features' only when the answer is non-empty

### DIFF
--- a/simpletransformers/question_answering/question_answering_model.py
+++ b/simpletransformers/question_answering/question_answering_model.py
@@ -255,7 +255,7 @@ class QuestionAnsweringModel:
         self._move_model_to_device()
 
         if isinstance(train_data, str):
-            with open(train_data, "r", encoding="utf-8") as f:
+            with open(train_data, "r") as f:
                 train_examples = json.load(f)
         else:
             train_examples = train_data
@@ -526,7 +526,7 @@ class QuestionAnsweringModel:
         all_predictions, all_nbest_json, scores_diff_json = self.evaluate(eval_data, output_dir)
 
         if isinstance(eval_data, str):
-            with open(eval_data, "r", encoding="utf-8") as f:
+            with open(eval_data, "r") as f:
                 truth = json.load(f)
         else:
             truth = eval_data
@@ -552,7 +552,7 @@ class QuestionAnsweringModel:
         args = self.args
 
         if isinstance(eval_data, str):
-            with open(eval_data, "r", encoding="utf-8") as f:
+            with open(eval_data, "r") as f:
                 eval_examples = json.load(f)
         else:
             eval_examples = eval_data

--- a/simpletransformers/question_answering/question_answering_model.py
+++ b/simpletransformers/question_answering/question_answering_model.py
@@ -255,7 +255,7 @@ class QuestionAnsweringModel:
         self._move_model_to_device()
 
         if isinstance(train_data, str):
-            with open(train_data, "r") as f:
+            with open(train_data, "r", encoding="utf-8") as f:
                 train_examples = json.load(f)
         else:
             train_examples = train_data
@@ -526,7 +526,7 @@ class QuestionAnsweringModel:
         all_predictions, all_nbest_json, scores_diff_json = self.evaluate(eval_data, output_dir)
 
         if isinstance(eval_data, str):
-            with open(eval_data, "r") as f:
+            with open(eval_data, "r", encoding="utf-8") as f:
                 truth = json.load(f)
         else:
             truth = eval_data
@@ -552,7 +552,7 @@ class QuestionAnsweringModel:
         args = self.args
 
         if isinstance(eval_data, str):
-            with open(eval_data, "r") as f:
+            with open(eval_data, "r", encoding="utf-8") as f:
                 eval_examples = json.load(f)
         else:
             eval_examples = eval_data

--- a/simpletransformers/question_answering/question_answering_utils.py
+++ b/simpletransformers/question_answering/question_answering_utils.py
@@ -600,8 +600,8 @@ def write_predictions(
         for pred in prelim_predictions:
             if len(nbest) >= n_best_size:
                 break
-            feature = features[pred.feature_index]
             if pred.start_index > 0:  # this is a non-null prediction
+                feature = features[pred.feature_index]
                 tok_tokens = feature.tokens[pred.start_index : (pred.end_index + 1)]
                 orig_doc_start = feature.token_to_orig_map[pred.start_index]
                 orig_doc_end = feature.token_to_orig_map[pred.end_index]
@@ -993,8 +993,8 @@ def get_best_predictions(
         for pred in prelim_predictions:
             if len(nbest) >= n_best_size:
                 break
-            feature = features[pred.feature_index]
             if pred.start_index > 0:  # this is a non-null prediction
+                feature = features[pred.feature_index]
                 tok_tokens = feature.tokens[pred.start_index : (pred.end_index + 1)]
                 orig_doc_start = feature.token_to_orig_map[pred.start_index]
                 orig_doc_end = feature.token_to_orig_map[pred.end_index]


### PR DESCRIPTION
Because the empty answer ( which will occur when 'version_2_with_negative' is set to True) has an empty 'features', the previous code will meet a 'list out of index' error for trying indexing on an empty list.

Therefore, initialize the 'feature' by 'features' only when the 'pred.start_index' is greater than 0 can simply fix it. (pred.start_index > 0 means the answer is not empty.)

Moreover, for we do not need the variable 'feature' while the answer is empty, it's OK to do so.