### PR TITLE
Classification report included and non printable character bug fixed

### DIFF
--- a/simpletransformers/config/global_args.py
+++ b/simpletransformers/config/global_args.py
@@ -26,7 +26,6 @@ global_args = {
     "evaluate_during_training": False,
     "evaluate_during_training_steps": 2000,
     "evaluate_during_training_verbose": False,
-    "classification_report": False,
     "use_cached_eval_features": False,
     "save_eval_checkpoints": True,
     "tensorboard_dir": None,

--- a/simpletransformers/config/global_args.py
+++ b/simpletransformers/config/global_args.py
@@ -26,6 +26,7 @@ global_args = {
     "evaluate_during_training": False,
     "evaluate_during_training_steps": 2000,
     "evaluate_during_training_verbose": False,
+    "classification_report": False,
     "use_cached_eval_features": False,
     "save_eval_checkpoints": True,
     "tensorboard_dir": None,

--- a/simpletransformers/ner/ner_model.py
+++ b/simpletransformers/ner/ner_model.py
@@ -552,7 +552,7 @@ class NERModel:
                 cls_report = classification_report(out_label_list, preds_list)
                 writer.write("{}\n".format(cls_report))
             for key in sorted(result.keys()):
-                    writer.write("{} = {}\n".format(key, str(result[key])))
+                writer.write("{} = {}\n".format(key, str(result[key])))
 
         return results, model_outputs, preds_list
 

--- a/simpletransformers/ner/ner_model.py
+++ b/simpletransformers/ner/ner_model.py
@@ -127,7 +127,7 @@ class NERModel:
         self.results = {}
 
         self.args = {}
-
+        self.args = {"classification_report": False}
         self.args.update(global_args)
 
         if not use_cuda:

--- a/simpletransformers/ner/ner_model.py
+++ b/simpletransformers/ner/ner_model.py
@@ -12,7 +12,7 @@ import numpy as np
 import pandas as pd
 
 from scipy.stats import pearsonr
-from seqeval.metrics import precision_score, recall_score, f1_score
+from seqeval.metrics import precision_score, recall_score, f1_score, classification_report
 from tensorboardX import SummaryWriter
 from tqdm.auto import trange, tqdm
 
@@ -548,8 +548,11 @@ class NERModel:
 
         output_eval_file = os.path.join(eval_output_dir, "eval_results.txt")
         with open(output_eval_file, "w") as writer:
+            if args["classification_report"]:
+                cls_report = classification_report(out_label_list, preds_list)
+                writer.write("{}\n".format(cls_report))
             for key in sorted(result.keys()):
-                writer.write("{} = {}\n".format(key, str(result[key])))
+                    writer.write("{} = {}\n".format(key, str(result[key])))
 
         return results, model_outputs, preds_list
 

--- a/simpletransformers/ner/ner_utils.py
+++ b/simpletransformers/ner/ner_utils.py
@@ -110,7 +110,8 @@ def convert_example_to_feature(example_row):
         word_tokens = tokenizer.tokenize(word)
         tokens.extend(word_tokens)
         # Use the real label id for the first token of the word, and padding ids for the remaining tokens
-        label_ids.extend([label_map[label]] + [pad_token_label_id] * (len(word_tokens) - 1))
+        if word_tokens:
+            label_ids.extend([label_map[label]] + [pad_token_label_id] * (len(word_tokens) - 1))
 
     # Account for [CLS] and [SEP] with "- 2" and with "- 3" for RoBERTa.
     special_tokens_count = 3 if sep_token_extra else 2

--- a/simpletransformers/ner/ner_utils.py
+++ b/simpletransformers/ner/ner_utils.py
@@ -110,7 +110,7 @@ def convert_example_to_feature(example_row):
         word_tokens = tokenizer.tokenize(word)
         tokens.extend(word_tokens)
         # Use the real label id for the first token of the word, and padding ids for the remaining tokens
-        if word_tokens:
+        if word_tokens: # avoid non printable character like '\u200e' which are tokenized as a void token ''
             label_ids.extend([label_map[label]] + [pad_token_label_id] * (len(word_tokens) - 1))
 
     # Account for [CLS] and [SEP] with "- 2" and with "- 3" for RoBERTa.


### PR DESCRIPTION
- Included the classification report for NER. It is useful for NER to understand the accuracy for each single tag. I included the classification report on the top of the `eval_results.txt` file.

- I fixed a bug occurring when non-printable characters are present inside the source file. In wikiNER dataset some non-printable characters are present and the associated label is 'O'. Anyway the tokenizer outputs a void token for them and so the length of the label list will be greater than the one of the tokenized words causing the assert to fail.