### PR TITLE
best_model_dir arg is used but not specified in the args list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1565,7 +1565,7 @@ key: value pairs to the the init method of a Model class.
 self.args = {
   "output_dir": "outputs/",
   "cache_dir": "cache/",
-  "best_model_dir": "best_model/",
+  "best_model_dir": "outputs/best_model/",
 
   "fp16": True,
   "fp16_opt_level": "O1",

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ This library is based on the [Transformers](https://github.com/huggingface/trans
     - [Args Explained](#args-explained)
       - [*output_dir: str*](#outputdir-str)
       - [*cache_dir: str*](#cachedir-str)
+      - [*best_model_dir: str*](#bestmodeldir-str)
       - [*fp16: bool*](#fp16-bool)
       - [*fp16_opt_level: str*](#fp16optlevel-str)
       - [*max_seq_length: int*](#maxseqlength-int)

--- a/README.md
+++ b/README.md
@@ -1564,6 +1564,7 @@ key: value pairs to the the init method of a Model class.
 self.args = {
   "output_dir": "outputs/",
   "cache_dir": "cache/",
+  "best_model_dir": "best_model/",
 
   "fp16": True,
   "fp16_opt_level": "O1",
@@ -1617,6 +1618,9 @@ The directory where all outputs will be stored. This includes model checkpoints 
 
 #### *cache_dir: str*
 The directory where cached files will be saved.
+
+#### *best_model_dir: str*
+The directory where the best model (model checkpoints) will be saved if evaluate_during_training is enabled and the training loop achieves a lowest evaluation loss calculated after every evaluate_during_training_steps, or an epoch.
 
 #### *fp16: bool*
 Whether or not fp16 mode should be used. Requires NVidia Apex library.


### PR DESCRIPTION
The `train` function of the `*_model.py` files use the arg `best_model_dir ` from `self.args` when `evaluate_during_training` is set to `True` to save the model checkpoints to a `best_model_dir`  directory when the `best_eval_loss` is `True` (or `best_correct_answers` for QA) which is calculated after every `evaluate_during_training_steps` and an epoch when `evaluate_during_training` is `True`. The default value of `best_model_dir` is `outputs/best_model` dir from where the script is executed. This is a problem when you change the `output_dir` in the args list when executing script, and the `best_model_dir` remains unchanged, leading to a new `outputs/best_model/ `dir directory outside of the new `args[output_dir]`

Currently, the `best_model_dir` is not listed in the args list in `README.md`. After this PR, the `best_model_dir` is listed in the args list of `README.md`. This makes the `best_model_dir` arg apparent to the user as configurable.