### PR TITLE
remove concatenated paths with os.path.join()

### DIFF
--- a/simpletransformers/classification/classification_model.py
+++ b/simpletransformers/classification/classification_model.py
@@ -432,7 +432,7 @@ class ClassificationModel:
                             training_progress_scores[key].append(results[key])
                         report = pd.DataFrame(training_progress_scores)
                         report.to_csv(
-                            args["output_dir"] + "training_progress_scores.csv", index=False,
+                            os.path.join(args["output_dir"], "training_progress_scores.csv"), index=False,
                         )
 
                         if args["wandb_project"]:
@@ -483,7 +483,7 @@ class ClassificationModel:
                 for key in results:
                     training_progress_scores[key].append(results[key])
                 report = pd.DataFrame(training_progress_scores)
-                report.to_csv(args["output_dir"] + "training_progress_scores.csv", index=False)
+                report.to_csv(os.path.join(args["output_dir"], "training_progress_scores.csv"), index=False)
 
                 if not best_eval_loss:
                     best_eval_loss = results["eval_loss"]

--- a/simpletransformers/conv_ai/conv_ai_model.py
+++ b/simpletransformers/conv_ai/conv_ai_model.py
@@ -385,7 +385,7 @@ class ConvAIModel:
                             training_progress_scores[key].append(results[key])
                         report = pd.DataFrame(training_progress_scores)
                         report.to_csv(
-                            args["output_dir"] + "training_progress_scores.csv", index=False,
+                            os.path.join(args["output_dir"], "training_progress_scores.csv"), index=False,
                         )
 
                         if args["wandb_project"]:
@@ -436,7 +436,7 @@ class ConvAIModel:
                 for key in results:
                     training_progress_scores[key].append(results[key])
                 report = pd.DataFrame(training_progress_scores)
-                report.to_csv(args["output_dir"] + "training_progress_scores.csv", index=False)
+                report.to_csv(os.path.join(args["output_dir"], "training_progress_scores.csv"), index=False)
 
                 if not best_eval_loss:
                     best_eval_loss = results["eval_loss"]

--- a/simpletransformers/ner/ner_model.py
+++ b/simpletransformers/ner/ner_model.py
@@ -362,7 +362,7 @@ class NERModel:
                             training_progress_scores[key].append(results[key])
                         report = pd.DataFrame(training_progress_scores)
                         report.to_csv(
-                            args["output_dir"] + "training_progress_scores.csv", index=False,
+                            os.path.join(args["output_dir"], "training_progress_scores.csv"), index=False,
                         )
 
                         if args["wandb_project"]:
@@ -411,7 +411,7 @@ class NERModel:
                 for key in results:
                     training_progress_scores[key].append(results[key])
                 report = pd.DataFrame(training_progress_scores)
-                report.to_csv(args["output_dir"] + "training_progress_scores.csv", index=False)
+                report.to_csv(os.path.join(args["output_dir"], "training_progress_scores.csv"), index=False)
 
                 if not best_eval_loss:
                     best_eval_loss = results["eval_loss"]

--- a/simpletransformers/question_answering/question_answering_model.py
+++ b/simpletransformers/question_answering/question_answering_model.py
@@ -427,7 +427,7 @@ class QuestionAnsweringModel:
                             training_progress_scores[key].append(results[key])
                         report = pd.DataFrame(training_progress_scores)
                         report.to_csv(
-                            args["output_dir"] + "training_progress_scores.csv", index=False,
+                            os.path.join(args["output_dir"], "training_progress_scores.csv"), index=False,
                         )
 
                         if args["wandb_project"]:
@@ -476,7 +476,7 @@ class QuestionAnsweringModel:
                 for key in results:
                     training_progress_scores[key].append(results[key])
                 report = pd.DataFrame(training_progress_scores)
-                report.to_csv(args["output_dir"] + "training_progress_scores.csv", index=False)
+                report.to_csv(os.path.join(args["output_dir"], "training_progress_scores.csv"), index=False)
 
                 if not best_correct_answers:
                     best_correct_answers = results["correct"]


### PR DESCRIPTION
The `training_progress_scores` in the `train` function of the `*_model.py` files are saved to the CSV file with the path `'training_progress_scores.csv' `string concatenated with `args["output_dir"]`. This leads to several problems:

1. The user has to supply the training backslashes in the `output_dir` arg. This can easily be forgotten by the user. With this PR, **the user does not have to worry about the trailing backslashes.**
2. The default value of the `args[output_dir]` is followed by a single trailing backslash, which is not compatible with the Windows paths, which require double backslashes (in string format), or a single forward slash. **`os.path.join()` makes it portable**.
3. Many codebases take `Pathlib.Path` as an input, which strips off the trailing backslash in the default mode. When integrating this library with another codebase which takes `Pathlib.Path` as input, the `training_progress_scores.csv` is saved in a new directory because the current codebase 'string concatenates' the `Pathlib.Path` (without trailing backslash) and a string leading to a new file path. For example, if:
`output_dir = Pathlib.Path('output_dir/')`
then the `training_progress_scores.csv` is saved to:
`outputdirtraining_progress_scores.csv` instead of `output_dir/training_progress_scores.csv`. **This PR makes this package more integratable without losing the current functionalities.**
4. The `os.path.join()` is used in all other modules of this package as well for path specification, therefore t**his PR makes the path specification consistent with the rest of the package.**

