### PR TITLE
(Fix) Fixed passing proxies kwargs into ConvAI model

### DIFF
--- a/simpletransformers/conv_ai/conv_ai_model.py
+++ b/simpletransformers/conv_ai/conv_ai_model.py
@@ -200,12 +200,13 @@ class ConvAIModel:
 
         train_dataloader, train_sampler = self.load_and_cache_examples(
             dataset_path=train_file,
+            proxies=kwargs.get('proxies',{}),
             verbose=verbose,
             no_cache=self.args["no_cache"] or self.args["reprocess_input_data"],
         )
 
         if self.args["evaluate_during_training"]:
-            eval_loader, eval_sampler = self.load_and_cache_examples(verbose=verbose, evaluate=True)
+            eval_loader, eval_sampler = self.load_and_cache_examples(verbose=verbose, proxies=kwargs.get('proxies',{}), evaluate=True)
         else:
             eval_loader = None
 
@@ -518,6 +519,7 @@ class ConvAIModel:
 
         eval_dataloader, eval_sampler = self.load_and_cache_examples(
             eval_file,
+            proxies=kwargs.get('proxies',{}),
             evaluate=True,
             verbose=verbose,
             silent=silent,
@@ -564,7 +566,7 @@ class ConvAIModel:
 
         return results
 
-    def load_and_cache_examples(self, dataset_path=None, evaluate=False, no_cache=False, verbose=True, silent=False):
+    def load_and_cache_examples(self, dataset_path=None, proxies={}, evaluate=False, no_cache=False, verbose=True, silent=False):
         """
         Loads, tokenizes, and prepares data for training and/or evaluation.
 
@@ -588,6 +590,7 @@ class ConvAIModel:
             dataset_path,
             args["cache_dir"],
             process_count=process_count,
+            proxies=proxies,
             evaluate=evaluate,
             no_cache=no_cache,
         )

--- a/simpletransformers/conv_ai/conv_ai_model.py
+++ b/simpletransformers/conv_ai/conv_ai_model.py
@@ -103,6 +103,7 @@ class ConvAIModel:
                 torch.cuda.manual_seed_all(args["manual_seed"])
 
         config_class, model_class, tokenizer_class = MODEL_CLASSES[model_type]
+        self.__dict__.update(kwargs)
 
         if use_cuda:
             if torch.cuda.is_available():
@@ -200,13 +201,12 @@ class ConvAIModel:
 
         train_dataloader, train_sampler = self.load_and_cache_examples(
             dataset_path=train_file,
-            proxies=kwargs.get('proxies',{}),
             verbose=verbose,
             no_cache=self.args["no_cache"] or self.args["reprocess_input_data"],
         )
 
         if self.args["evaluate_during_training"]:
-            eval_loader, eval_sampler = self.load_and_cache_examples(verbose=verbose, proxies=kwargs.get('proxies',{}), evaluate=True)
+            eval_loader, eval_sampler = self.load_and_cache_examples(verbose=verbose, evaluate=True)
         else:
             eval_loader = None
 
@@ -519,7 +519,6 @@ class ConvAIModel:
 
         eval_dataloader, eval_sampler = self.load_and_cache_examples(
             eval_file,
-            proxies=kwargs.get('proxies',{}),
             evaluate=True,
             verbose=verbose,
             silent=silent,
@@ -566,7 +565,7 @@ class ConvAIModel:
 
         return results
 
-    def load_and_cache_examples(self, dataset_path=None, proxies={}, evaluate=False, no_cache=False, verbose=True, silent=False):
+    def load_and_cache_examples(self, dataset_path=None, evaluate=False, no_cache=False, verbose=True, silent=False):
         """
         Loads, tokenizes, and prepares data for training and/or evaluation.
 
@@ -590,7 +589,7 @@ class ConvAIModel:
             dataset_path,
             args["cache_dir"],
             process_count=process_count,
-            proxies=proxies,
+            proxies=self.__dict__.get(proxies,None),
             evaluate=evaluate,
             no_cache=no_cache,
         )

--- a/simpletransformers/conv_ai/conv_ai_model.py
+++ b/simpletransformers/conv_ai/conv_ai_model.py
@@ -589,7 +589,7 @@ class ConvAIModel:
             dataset_path,
             args["cache_dir"],
             process_count=process_count,
-            proxies=self.__dict__.get(proxies,None),
+            proxies=self.__dict__.get('proxies',None),
             evaluate=evaluate,
             no_cache=no_cache,
         )

--- a/simpletransformers/conv_ai/conv_ai_utils.py
+++ b/simpletransformers/conv_ai/conv_ai_utils.py
@@ -44,7 +44,7 @@ def tokenize_multi(data):
     return list(tokenize_multi((o, tokenizer)) for o in obj)
 
 
-def get_dataset(tokenizer, dataset_path, dataset_cache, process_count, proxies={}, evaluate=False, interact=False, no_cache=False):
+def get_dataset(tokenizer, dataset_path, dataset_cache, process_count, proxies, evaluate=False, interact=False, no_cache=False):
     """ Get tokenized PERSONACHAT dataset from S3 or cache."""
     dataset_path = dataset_path or PERSONACHAT_URL
 

--- a/simpletransformers/conv_ai/conv_ai_utils.py
+++ b/simpletransformers/conv_ai/conv_ai_utils.py
@@ -44,7 +44,7 @@ def tokenize_multi(data):
     return list(tokenize_multi((o, tokenizer)) for o in obj)
 
 
-def get_dataset(tokenizer, dataset_path, dataset_cache, process_count, evaluate=False, interact=False, no_cache=False):
+def get_dataset(tokenizer, dataset_path, dataset_cache, process_count, proxies={}, evaluate=False, interact=False, no_cache=False):
     """ Get tokenized PERSONACHAT dataset from S3 or cache."""
     dataset_path = dataset_path or PERSONACHAT_URL
 
@@ -60,7 +60,7 @@ def get_dataset(tokenizer, dataset_path, dataset_cache, process_count, evaluate=
         dataset = torch.load(dataset_cache)
     else:
         logger.info("Download dataset from %s", dataset_path)
-        personachat_file = cached_path(dataset_path)
+        personachat_file = cached_path(dataset_path, proxies=proxies)
         with open(personachat_file, "r", encoding="utf-8") as f:
             dataset = json.loads(f.read())
 


### PR DESCRIPTION
Constructor can be passed a proxies argument which is picked up and used by load_examples_and_cache function when it calls the get_dataset() function. 