### PR TITLE
Fixing error in Minimal Start for Multilabel Classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ transformers_logger = logging.getLogger("transformers")
 transformers_logger.setLevel(logging.WARNING)
 
 # Train and Evaluation data needs to be in a Pandas Dataframe containing at least two columns, a 'text' and a 'labels' column. The `labels` column should contain multi-hot encoded lists.
-train_data = [['Example sentence 1 for multilabel classification.', [1, 1, 1, 1, 0, 1]]], [['This is another example sentence. ', [0, 1, 1, 0, 0, 0]]]
+train_data = [['Example sentence 1 for multilabel classification.', [1, 1, 1, 1, 0, 1]], ['This is another example sentence. ', [0, 1, 1, 0, 0, 0]]]
 train_df = pd.DataFrame(train_data, columns=['text', 'labels'])
 
 eval_data = [['Example eval sentence for multilabel classification.', [1, 1, 1, 1, 0, 1]], ['Example eval senntence belonging to class 2', [0, 1, 1, 0, 0, 0]]]


### PR DESCRIPTION
Fix for typo in the brackets in the given example for "Minimal start for multilabel classification".