### PR TITLE
Add longformer to list of space prefix model types

### DIFF
--- a/simpletransformers/classification/classification_model.py
+++ b/simpletransformers/classification/classification_model.py
@@ -836,7 +836,7 @@ class ClassificationModel:
                 sep_token=tokenizer.sep_token,
                 # RoBERTa uses an extra separator b/w pairs of sentences,
                 # cf. github.com/pytorch/fairseq/commit/1684e166e3da03f5b600dbb7855cb98ddfcd0805
-                sep_token_extra=bool(args["model_type"] in ["roberta", "camembert", "xlmroberta"]),
+                sep_token_extra=bool(args["model_type"] in ["roberta", "camembert", "xlmroberta", "longformer"]),
                 # PAD on the left for XLNet
                 pad_on_left=bool(args["model_type"] in ["xlnet"]),
                 pad_token=tokenizer.convert_tokens_to_ids([tokenizer.pad_token])[0],
@@ -848,7 +848,7 @@ class ClassificationModel:
                 sliding_window=args["sliding_window"],
                 flatten=not evaluate,
                 stride=args["stride"],
-                add_prefix_space=bool(args["model_type"] in ["roberta", "camembert", "xlmroberta"]),
+                add_prefix_space=bool(args["model_type"] in ["roberta", "camembert", "xlmroberta", "longformer"]),
                 args=args,
             )
             if verbose and args["sliding_window"]:


### PR DESCRIPTION
Added to list of extra SEP token models as well. Longformer uses Roberta's tokenization.