### PR TITLE
allow custom models

### DIFF
--- a/simpletransformers/classification/classification_model.py
+++ b/simpletransformers/classification/classification_model.py
@@ -81,7 +81,7 @@ logger = logging.getLogger(__name__)
 
 class ClassificationModel:
     def __init__(
-        self, model_type, model_name, num_labels=None, weight=None, args=None, use_cuda=True, cuda_device=-1, **kwargs,
+        self, model_type, model_name, num_labels=None, weight=None, args=None, use_cuda=True, cuda_device=-1, model_config = None, model_head = None, model_tokenizer = None, **kwargs,
     ):
 
         """
@@ -110,6 +110,7 @@ class ClassificationModel:
             "xlnet": (XLNetConfig, XLNetForSequenceClassification, XLNetTokenizer),
             "xlm": (XLMConfig, XLMForSequenceClassification, XLMTokenizer),
             "xlmroberta": (XLMRobertaConfig, XLMRobertaForSequenceClassification, XLMRobertaTokenizer),
+            "custom": (model_config, model_head, model_tokenizer),
         }
 
         if args and "manual_seed" in args:

--- a/simpletransformers/conv_ai/conv_ai_model.py
+++ b/simpletransformers/conv_ai/conv_ai_model.py
@@ -69,7 +69,7 @@ PADDED_INPUTS = ["input_ids", "lm_labels", "token_type_ids"]
 
 class ConvAIModel:
     def __init__(
-        self, model_type, model_name, args=None, use_cuda=True, cuda_device=-1, **kwargs,
+        self, model_type, model_name, args=None, use_cuda=True, cuda_device=-1, model_config = None, model_head = None, model_tokenizer = None, **kwargs,
     ):
 
         """
@@ -87,6 +87,7 @@ class ConvAIModel:
         MODEL_CLASSES = {
             "gpt": (OpenAIGPTConfig, OpenAIGPTDoubleHeadsModel, OpenAIGPTTokenizer),
             "gpt2": (GPT2Config, GPT2DoubleHeadsModel, GPT2Tokenizer),
+            "custom": (model_config, model_head, model_tokenizer),
         }
 
         if args and "manual_seed" in args:

--- a/simpletransformers/language_generation/language_generation_model.py
+++ b/simpletransformers/language_generation/language_generation_model.py
@@ -37,7 +37,7 @@ MAX_LENGTH = int(10000)  # Hardcoded max length to avoid infinite loop
 
 class LanguageGenerationModel:
     def __init__(
-        self, model_type, model_name, args=None, use_cuda=True, cuda_device=-1, **kwargs,
+        self, model_type, model_name, args=None, use_cuda=True, cuda_device=-1, model_config = None, model_head = None, model_tokenizer = None, **kwargs,
     ):
 
         """
@@ -59,6 +59,7 @@ class LanguageGenerationModel:
             "xlnet": (XLNetConfig, XLNetLMHeadModel, XLNetTokenizer),
             "transfo-xl": (TransfoXLConfig, TransfoXLLMHeadModel, TransfoXLTokenizer),
             "xlm": (XLMConfig, XLMWithLMHeadModel, XLMTokenizer),
+            "custom": (model_config, model_head, model_tokenizer),
         }
 
         if args and "manual_seed" in args:

--- a/simpletransformers/language_modeling/language_modeling_model.py
+++ b/simpletransformers/language_modeling/language_modeling_model.py
@@ -83,18 +83,6 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
-MODEL_CLASSES = {
-    "auto": (AutoConfig, AutoModelWithLMHead, AutoTokenizer),
-    "bert": (BertConfig, BertForMaskedLM, BertTokenizer),
-    "camembert": (CamembertConfig, CamembertForMaskedLM, CamembertTokenizer),
-    "distilbert": (DistilBertConfig, DistilBertForMaskedLM, DistilBertTokenizer),
-    "electra": (ElectraConfig, ElectraForLanguageModelingModel, ElectraTokenizer),
-    "gpt2": (GPT2Config, GPT2LMHeadModel, GPT2Tokenizer),
-    "longformer": (LongformerConfig, LongformerForMaskedLM, LongformerTokenizer),
-    "openai-gpt": (OpenAIGPTConfig, OpenAIGPTLMHeadModel, OpenAIGPTTokenizer),
-    "roberta": (RobertaConfig, RobertaForMaskedLM, RobertaTokenizer),
-}
-
 
 class LanguageModelingModel:
     def __init__(
@@ -107,6 +95,9 @@ class LanguageModelingModel:
         args=None,
         use_cuda=True,
         cuda_device=-1,
+        model_config = None, 
+        model_head = None, 
+        model_tokenizer = None,
         **kwargs,
     ):
 
@@ -124,6 +115,20 @@ class LanguageModelingModel:
             cuda_device (optional): Specific GPU that should be used. Will use the first available GPU by default.
             **kwargs (optional): For providing proxies, force_download, resume_download, cache_dir and other options specific to the 'from_pretrained' implementation where this will be supplied.
         """  # noqa: ignore flake8"
+        
+        
+        MODEL_CLASSES = {
+            "auto": (AutoConfig, AutoModelWithLMHead, AutoTokenizer),
+            "bert": (BertConfig, BertForMaskedLM, BertTokenizer),
+            "camembert": (CamembertConfig, CamembertForMaskedLM, CamembertTokenizer),
+            "distilbert": (DistilBertConfig, DistilBertForMaskedLM, DistilBertTokenizer),
+            "electra": (ElectraConfig, ElectraForLanguageModelingModel, ElectraTokenizer),
+            "gpt2": (GPT2Config, GPT2LMHeadModel, GPT2Tokenizer),
+            "longformer": (LongformerConfig, LongformerForMaskedLM, LongformerTokenizer),
+            "openai-gpt": (OpenAIGPTConfig, OpenAIGPTLMHeadModel, OpenAIGPTTokenizer),
+            "roberta": (RobertaConfig, RobertaForMaskedLM, RobertaTokenizer),
+            "custom": (model_config, model_head, model_tokenizer),
+        }
 
         if args and "manual_seed" in args:
             random.seed(args["manual_seed"])

--- a/simpletransformers/ner/ner_model.py
+++ b/simpletransformers/ner/ner_model.py
@@ -68,7 +68,7 @@ logger = logging.getLogger(__name__)
 
 class NERModel:
     def __init__(
-        self, model_type, model_name, labels=None, args=None, use_cuda=True, cuda_device=-1, **kwargs,
+        self, model_type, model_name, labels=None, args=None, use_cuda=True, cuda_device=-1, model_config = None, model_head = None, model_tokenizer = None, **kwargs,
     ):
         """
         Initializes a NERModel
@@ -132,6 +132,7 @@ class NERModel:
             "longformer": (LongformerConfig, LongformerForTokenClassification, LongformerTokenizer),
             "roberta": (RobertaConfig, RobertaForTokenClassification, RobertaTokenizer),
             "xlmroberta": (XLMRobertaConfig, XLMRobertaForTokenClassification, XLMRobertaTokenizer),
+            "custom": (model_config, model_head, model_tokenizer),
         }
 
         config_class, model_class, tokenizer_class = MODEL_CLASSES[model_type]

--- a/simpletransformers/question_answering/question_answering_model.py
+++ b/simpletransformers/question_answering/question_answering_model.py
@@ -84,7 +84,7 @@ logger = logging.getLogger(__name__)
 
 
 class QuestionAnsweringModel:
-    def __init__(self, model_type, model_name, args=None, use_cuda=True, cuda_device=-1, **kwargs):
+    def __init__(self, model_type, model_name, args=None, use_cuda=True, cuda_device=-1, model_config = None, model_head = None, model_tokenizer = None, **kwargs):
 
         """
         Initializes a QuestionAnsweringModel model.
@@ -109,6 +109,7 @@ class QuestionAnsweringModel:
             "xlm": (XLMConfig, XLMForQuestionAnswering, XLMTokenizer),
             "xlmroberta": (XLMRobertaConfig, XLMRobertaForQuestionAnswering, XLMRobertaTokenizer),
             "xlnet": (XLNetConfig, XLNetForQuestionAnswering, XLNetTokenizer),
+            "custom": (model_config, model_head, model_tokenizer),
         }
 
         if args and "manual_seed" in args:

--- a/simpletransformers/seq2seq/seq2seq_model.py
+++ b/simpletransformers/seq2seq/seq2seq_model.py
@@ -61,18 +61,6 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
-MODEL_CLASSES = {
-    "auto": (AutoConfig, AutoModel, AutoTokenizer),
-    "bart": (BartConfig, BartForConditionalGeneration, BartTokenizer),
-    "bert": (BertConfig, BertModel, BertTokenizer),
-    "camembert": (CamembertConfig, CamembertModel, CamembertTokenizer),
-    "distilbert": (DistilBertConfig, DistilBertModel, DistilBertTokenizer),
-    "electra": (ElectraConfig, ElectraModel, ElectraTokenizer),
-    "longformer": (LongformerConfig, LongformerModel, LongformerTokenizer),
-    "marian": (MarianConfig, MarianMTModel, MarianTokenizer),
-    "roberta": (RobertaConfig, RobertaModel, RobertaTokenizer),
-}
-
 
 class Seq2SeqModel:
     def __init__(
@@ -86,9 +74,25 @@ class Seq2SeqModel:
         args=None,
         use_cuda=True,
         cuda_device=-1,
+        model_config = None,
+        model_head = None,
+        model_tokenizer = None,
         **kwargs,
     ):
 
+        
+        MODEL_CLASSES = {
+            "auto": (AutoConfig, AutoModel, AutoTokenizer),
+            "bart": (BartConfig, BartForConditionalGeneration, BartTokenizer),
+            "bert": (BertConfig, BertModel, BertTokenizer),
+            "camembert": (CamembertConfig, CamembertModel, CamembertTokenizer),
+            "distilbert": (DistilBertConfig, DistilBertModel, DistilBertTokenizer),
+            "electra": (ElectraConfig, ElectraModel, ElectraTokenizer),
+            "longformer": (LongformerConfig, LongformerModel, LongformerTokenizer),
+            "marian": (MarianConfig, MarianMTModel, MarianTokenizer),
+            "roberta": (RobertaConfig, RobertaModel, RobertaTokenizer),
+            "custom": (model_config, model_head, model_tokenizer),
+        }
         """
         Initializes a Seq2SeqModel.
 


### PR DESCRIPTION
This PR allows the user to use custom models or models from huggingface that are not released in this repo yet.
You can just initialize the models using model type = "custom"
This would make testing if new models works much easier, so you can test if it works without changing any code here.
For example there is an open PR for reformer classification head at huggingface repo, you could test it using this library without any changes

Example:
```
from transformers import (
    DistilBertConfig,
    DistilBertForQuestionAnswering,
    DistilBertTokenizer
)
from simpletransformers.question_answering import QuestionAnsweringModel
model = QuestionAnsweringModel('custom', 'distilbert-base-uncased-distilled-squad', args={'reprocess_input_data': True, 'overwrite_output_dir': True}, model_config = DistilBertConfig, model_head = DistilBertForQuestionAnswering, model_tokenizer = DistilBertTokenizer)
```
