### PR TITLE
[FIX] Fixed a bug in the parameter controlling the length of the text generated by GPT-2

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Any feedback will be immensely helpful in improving the documentation! If you ha
     - [Additional attributes for Language Generation tasks](#additional-attributes-for-language-generation-tasks)
       - [*do_sample: bool*](#do_sample-bool)
       - [*prompt: str*](#prompt-str)
-      - [*length: int*](#length-int)
+      - [*max_length: int*](#max_length-int)
       - [*stop_token: str*](#stop_token-str)
       - [*temperature: float*](#temperature-float)
       - [*repetition_penalty: float*](#repetition_penalty-float)
@@ -1496,7 +1496,7 @@ If set to `False` greedy decoding is used. Otherwise sampling is used. Defaults 
 
 A prompt text for the model.
 
-#### *length: int*
+#### *max_length: int*
 
 Length of the text to generate
 

--- a/examples/language_generation/generate.py
+++ b/examples/language_generation/generate.py
@@ -6,9 +6,9 @@ logging.basicConfig(level=logging.INFO)
 transformers_logger = logging.getLogger("transformers")
 transformers_logger.setLevel(logging.WARNING)
 
-model = LanguageGenerationModel("gpt2", "outputs/from_scratch/", args={"length": 200})
-# model = LanguageGenerationModel("gpt2", "outputs/fine-tuned", args={"length": 200})
-# model = LanguageGenerationModel("gpt2", "gpt2", args={"length": 200})
+model = LanguageGenerationModel("gpt2", "outputs/from_scratch/", args={"max_length": 200})
+# model = LanguageGenerationModel("gpt2", "outputs/fine-tuned", args={"max_length": 200})
+# model = LanguageGenerationModel("gpt2", "gpt2", args={"max_length": 200})
 
 prompts = [
     "Despite the recent successes of deep learning, such models are still far from some human abilities like learning from few examples, reasoning and explaining decisions. In this paper, we focus on organ annotation in medical images and we introduce a reasoning framework that is based on learning fuzzy relations on a small dataset for generating explanations.",


### PR DESCRIPTION
The original code passes an argument named **length** to control the length of the textual output generated by GPT-2. This is the wrong parameter since the _LanguageGenerationModel_  does not have any private variables of this sort. The correct name for the parameter is **max_length** which is used by the _LanguageGenerationModel_  class in its constructor. 

Corrective changes were made to generate.py reflecting the same. The bug is now fixed and by passing a value for **max_length**, we can control the length of output generated by GPT-2.