### PR TITLE
Implements Lazy Loading for QA tasks

### DIFF
--- a/examples/question_answering/lazy_qa.py
+++ b/examples/question_answering/lazy_qa.py
@@ -1,0 +1,98 @@
+import json
+import logging
+import os
+
+from tqdm.auto import tqdm
+
+from simpletransformers.question_answering import QuestionAnsweringModel
+
+logging.basicConfig(level=logging.INFO)
+transformers_logger = logging.getLogger("transformers")
+transformers_logger.setLevel(logging.WARNING)
+
+# Create dummy data to use for training.
+train_data = [
+    {
+        "context": "This is the first context",
+        "qas": [
+            {
+                "id": "00001",
+                "is_impossible": False,
+                "question": "Which context is this?",
+                "answers": [{"text": "the first", "answer_start": 8}],
+            }
+        ],
+    },
+    {
+        "context": "Other legislation followed, including the Migratory Bird Conservation Act of 1929, a 1937 treaty prohibiting the hunting of right and gray whales,\
+            and the Bald Eagle Protection Act of 1940. These later laws had a low cost to society—the species were relatively rare—and little opposition was raised",
+        "qas": [
+            {
+                "id": "00002",
+                "is_impossible": False,
+                "question": "What was the cost to society?",
+                "answers": [{"text": "low cost", "answer_start": 225}],
+            },
+            {
+                "id": "00003",
+                "is_impossible": False,
+                "question": "What was the name of the 1937 treaty?",
+                "answers": [{"text": "Bald Eagle Protection Act", "answer_start": 167}],
+            },
+            {"id": "00004", "is_impossible": True, "question": "How did Alexandar Hamilton die?", "answers": [],},
+        ],
+    },
+]  # noqa: ignore flake8"
+
+for i in range(20):
+    train_data.extend(train_data)
+
+# Save as a JSON file
+os.makedirs("data", exist_ok=True)
+with open("data/train.json", "w") as f:
+    json.dump(train_data, f)
+
+# Save as a JSONL file
+with open('data/train.jsonl', 'w') as outfile:
+    for entry in tqdm(train_data):
+        json.dump(entry, outfile)
+        outfile.write('\n')
+
+train_args = {
+    "reprocess_input_data": True,
+    "overwrite_output_dir": True,
+    "evaluate_during_training": True,
+    "evaluate_during_training_steps": 10000,
+    "train_batch_size": 8,
+    "num_train_epochs": 1,
+    # 'wandb_project': 'test-new-project',
+    # "use_early_stopping": True,
+    "n_best_size": 3,
+    "fp16": False,
+    "no_save": True,
+    "manual_seed": 4,
+    "max_seq_length": 512,
+    "no_save": True,
+    "n_best_size": 10,
+    "lazy_loading": True,
+    # "use_multiprocessing": False,
+}
+
+# Create the QuestionAnsweringModel
+model = QuestionAnsweringModel("bert", "bert-base-cased", args=train_args, use_cuda=True, cuda_device=0)
+
+# Train the model with JSON file
+model.train_model("data/train.jsonl", eval_data="data/train.json")
+
+# Making predictions using the model.
+to_predict = [
+    {
+        "context": "Other legislation followed, including the Migratory Bird Conservation Act of 1929, a 1937 treaty prohibiting the hunting of right and gray whales,\
+            and the Bald Eagle Protection Act of 1940. These later laws had a low cost to society—the species were relatively rare—and little opposition was raised",
+        "qas": [{"question": "What was the name of the 1937 treaty?", "id": "0"}],
+    }
+]
+
+print(model.predict(to_predict, n_best_size=2))
+
+# flake8: noqa

--- a/simpletransformers/config/model_args.py
+++ b/simpletransformers/config/model_args.py
@@ -149,12 +149,13 @@ class QuestionAnsweringArgs(ModelArgs):
     """
 
     doc_stride: int = 384
-    max_query_length: int = 64
-    n_best_size: int = 20
-    max_answer_length: int = 100
-    null_score_diff_threshold: float = 0.0
     early_stopping_metric: str = "correct"
     early_stopping_metric_minimize: bool = False
+    lazy_loading: bool = False
+    max_answer_length: int = 100
+    max_query_length: int = 64
+    n_best_size: int = 20
+    null_score_diff_threshold: float = 0.0
 
 
 @dataclass

--- a/simpletransformers/question_answering/question_answering_utils.py
+++ b/simpletransformers/question_answering/question_answering_utils.py
@@ -1898,7 +1898,7 @@ class LazyQuestionAnsweringDataset(Dataset):
     #     return line_idx
 
     def __getitem__(self, idx):
-        line = linecache.getline(self.data_file, idx + 1)
+        line = linecache.getline(self.data_file, idx)
         qa_sample = json.loads(line)
         example = get_examples([qa_sample])[0]
         f = squad_convert_example_to_features(

--- a/simpletransformers/question_answering/question_answering_utils.py
+++ b/simpletransformers/question_answering/question_answering_utils.py
@@ -4,6 +4,7 @@ import collections
 import json
 import logging
 import math
+import mmap
 import os
 import re
 import string
@@ -11,8 +12,10 @@ from io import open
 from multiprocessing import Pool, cpu_count
 from functools import partial
 from pprint import pprint
+from torch.utils.data import Dataset
 
 from tqdm import tqdm, trange
+import linecache
 
 import torch
 from tensorboardX import SummaryWriter
@@ -1861,8 +1864,57 @@ def build_examples(to_predict):
         context = row["context"]
         for qa in row["qas"]:
             qa["answers"] = [{"text": " ", "answer_start": 0}]
-            qa["is_impossible"]: False
+            qa["is_impossible"] = False
         example = {"context": context, "qas": row["qas"]}
         examples.append(example)
 
     return examples
+
+
+class LazyQuestionAnsweringDataset(Dataset):
+    def __init__(self, data_file, tokenizer, args):
+        self.data_file = data_file
+        self.num_entries = self._get_n_lines(self.data_file)
+        self.tokenizer = tokenizer
+        self.args = args
+        squad_convert_example_to_features_init(self.tokenizer)
+
+    @staticmethod
+    def _get_n_lines(data_file):
+        with open(data_file, "r+", encoding="utf-8") as f:
+            buf = mmap.mmap(f.fileno(), 0)
+            lines = 0
+            readline = buf.readline
+            while readline():
+                lines += 1
+            return lines
+
+    # @staticmethod
+    # def _get_n_lines(data_file):
+    #     with open(data_file, encoding="utf-8") as f:
+    #         for line_idx, _ in enumerate(f, 1):
+    #             pass
+
+    #     return line_idx
+
+    def __getitem__(self, idx):
+        line = linecache.getline(self.data_file, idx + 1)
+        qa_sample = json.loads(line)
+        example = get_examples([qa_sample])[0]
+        f = squad_convert_example_to_features(
+            example, self.args.max_seq_length, self.args.doc_stride, self.args.max_query_length, True
+        )[0]
+
+        return (
+            torch.tensor(f.input_ids, dtype=torch.long),
+            torch.tensor(f.attention_mask, dtype=torch.long),
+            torch.tensor(f.token_type_ids, dtype=torch.long),
+            torch.tensor(f.cls_index, dtype=torch.long),
+            torch.tensor(f.start_position, dtype=torch.long),
+            torch.tensor(f.end_position, dtype=torch.long),
+            torch.tensor(f.p_mask, dtype=torch.float),
+            torch.tensor(f.is_impossible, dtype=torch.float)
+        )
+
+    def __len__(self):
+        return self.num_entries


### PR DESCRIPTION
This PR implements Lazy Loading support for training QA models.

Special requirements:
- Requires `train_data` to be a `str` pointing to a [JSONL](http://jsonlines.org/) file.
- Lazy loading is only supported for training and not for evaluation.

Testing:
- A minimal testing script can be found at `examples/question_answering/lazy_qa.py`

To do:
- Update docs