### PR TITLE
UnboundLocalError in experimental.simpletransformers#train

### DIFF
--- a/simpletransformers/experimental/classification/classification_model.py
+++ b/simpletransformers/experimental/classification/classification_model.py
@@ -308,6 +308,7 @@ class ClassificationModel:
                         else:
                             outputs = model(**inputs)
                         # model outputs are always tuple in pytorch-transformers (see doc)
+                    loss = outputs[0]
                 else:
                     if self.sliding_window:
                         outputs = model(inputs)


### PR DESCRIPTION
Hi @ThilinaRajapakse, thank you for developing this amazing library! I found a tiny bug in `experimental.ClassificationModel` (stack trace bellow) and fixed it.

I suppose this bug occurs when `fp16 == True && sliding_window == True`. If I misunderstand something, feel free to mention it.

## Code
```python
params = {
    "output_dir": "outputs/",
    "max_seq_length": 128,
    "train_batch_size": 32,
    "eval_batch_size": 64,
    "num_train_epochs": 50,
    "learning_rate": 1e-5,
    "manual_seed":SEED,
}
model = ClassificationModel('roberta', 'deepset/roberta-base-squad2', num_labels=4, sliding_window=True, args=params, use_cuda=True)
model.train_model(X_train)
```

## Stack trace

```
---------------------------------------------------------------------------
UnboundLocalError                         Traceback (most recent call last)
<ipython-input-6-28b13f7d4b3d> in <module>()
    101                             args=params, use_cuda=True)
    102 
--> 103 model.train_model(X_train)
    104 
    105 result, model_outputs, wrong_predictions = model.eval_model(X_valid, f1=metric_f1)

1 frames
/usr/local/lib/python3.6/dist-packages/simpletransformers/experimental/classification/classification_model.py in train(self, train_dataset, output_dir, show_running_loss, eval_df)
    317                     loss = outputs[0]
    318                 if show_running_loss:
--> 319                     print("\rRunning loss: %f" % loss, end="")
    320 
    321                 if args["n_gpu"] > 1:

UnboundLocalError: local variable 'loss' referenced before assignment
```