### PR TITLE
added the missing padding_strategy in the function squad_convert_examples_to_features

### DIFF
--- a/simpletransformers/question_answering/question_answering_utils.py
+++ b/simpletransformers/question_answering/question_answering_utils.py
@@ -389,6 +389,7 @@ def squad_convert_examples_to_features(
     doc_stride,
     max_query_length,
     is_training,
+    padding_strategy="max_length",
     return_dataset=False,
     threads=1,
     tqdm_enabled=True,
@@ -439,6 +440,7 @@ def squad_convert_examples_to_features(
                 max_seq_length=max_seq_length,
                 doc_stride=doc_stride,
                 max_query_length=max_query_length,
+                padding_strategy=padding_strategy,
                 is_training=is_training,
             )
             features = list(


### PR DESCRIPTION
Hi Thilina,

This is a PR to fix the issue  #689 where you get error message 
`TypeError: squad_convert_example_to_features() missing 1 required positional argument: 'padding_strategy'` if you train a QuestionAnweringModel.

This happens because the function squad_convert_example_to_features() from huggingface https://github.com/huggingface/transformers/blob/77abd1e79fc37efb45bde0041f9dad0eabc55517/src/transformers/data/processors/squad.py#L91 added padding_strategy as a mandatory argument. 

