### PR TITLE
Improved evaluation memory and speed efficiency in NER

### DIFF
--- a/simpletransformers/ner/ner_model.py
+++ b/simpletransformers/ner/ner_model.py
@@ -712,12 +712,12 @@ class NERModel:
             nb_eval_steps += 1
 
             if preds is None:
-                preds = logits.detach().cpu().numpy()
+                preds = np.argmax(logits.detach().cpu().numpy(), axis=2)
                 out_label_ids = inputs["labels"].detach().cpu().numpy()
                 out_input_ids = inputs["input_ids"].detach().cpu().numpy()
                 out_attention_mask = inputs["attention_mask"].detach().cpu().numpy()
             else:
-                preds = np.append(preds, logits.detach().cpu().numpy(), axis=0)
+                preds = np.append(preds, np.argmax(logits.detach().cpu().numpy(), axis=2), axis=0)
                 out_label_ids = np.append(out_label_ids, inputs["labels"].detach().cpu().numpy(), axis=0)
                 out_input_ids = np.append(out_input_ids, inputs["input_ids"].detach().cpu().numpy(), axis=0)
                 out_attention_mask = np.append(
@@ -726,7 +726,6 @@ class NERModel:
 
         eval_loss = eval_loss / nb_eval_steps
         token_logits = preds
-        preds = np.argmax(preds, axis=2)
 
         label_map = {i: label for i, label in enumerate(self.args.labels_list)}
 


### PR DESCRIPTION
Made evaluation more efficient time and memory wise.

Previously, all the predictions were appended after each batch and in the end the argmax is taken. Instead, we can just take an argmax for each batch and keep appending it saving both time and memory. Even in simple cases where we only have two tags, the new `preds` will be 50% smaller than the original `preds`. In my case (10,000+ tags) the original `evaluate` does not work and always throws a `MemoryError` even on a server with over 100GB of memory.