### PR TITLE
Include BERTweet

### DIFF
--- a/simpletransformers/classification/classification_model.py
+++ b/simpletransformers/classification/classification_model.py
@@ -102,7 +102,7 @@ class ClassificationModel:
         args=None,
         use_cuda=True,
         cuda_device=-1,
-        onnx_execution_provider=None
+        onnx_execution_provider=None,
         **kwargs,
     ):
 

--- a/simpletransformers/classification/classification_model.py
+++ b/simpletransformers/classification/classification_model.py
@@ -102,8 +102,7 @@ class ClassificationModel:
         args=None,
         use_cuda=True,
         cuda_device=-1,
-        onnx_execution_provider=None,
-        bertweet_normalization=False,
+        onnx_execution_provider=None
         **kwargs,
     ):
 
@@ -251,8 +250,8 @@ class ClassificationModel:
             except AttributeError:
                 raise AttributeError("fp16 requires Pytorch >= 1.6. Please update Pytorch or turn off fp16.")
                 
-        if model_name == 'vinai/bertweet-base':
-            self.tokenizer = tokenizer_class.from_pretrained(model_name, do_lower_case=self.args.do_lower_case, normalization=bertweet_normalization, **kwargs)
+        if model_name in ['vinai/bertweet-base', 'vinai/bertweet-covid19-base-cased', 'vinai/bertweet-covid19-base-uncased']:
+            self.tokenizer = tokenizer_class.from_pretrained(model_name, do_lower_case=self.args.do_lower_case, normalization=True, **kwargs)
         else:
             self.tokenizer = tokenizer_class.from_pretrained(model_name, do_lower_case=self.args.do_lower_case, **kwargs)
         

--- a/simpletransformers/classification/classification_model.py
+++ b/simpletransformers/classification/classification_model.py
@@ -103,6 +103,7 @@ class ClassificationModel:
         use_cuda=True,
         cuda_device=-1,
         onnx_execution_provider=None,
+        normalization=False,
         **kwargs,
     ):
 
@@ -249,9 +250,12 @@ class ClassificationModel:
                 from torch.cuda import amp
             except AttributeError:
                 raise AttributeError("fp16 requires Pytorch >= 1.6. Please update Pytorch or turn off fp16.")
-
-        self.tokenizer = tokenizer_class.from_pretrained(model_name, do_lower_case=self.args.do_lower_case, **kwargs)
-
+                
+        if model_name == 'vinai/bertweet-base':
+            self.tokenizer = tokenizer_class.from_pretrained(model_name, do_lower_case=self.args.do_lower_case, normalization=normalization, **kwargs)
+        else:
+            self.tokenizer = tokenizer_class.from_pretrained(model_name, do_lower_case=self.args.do_lower_case, **kwargs)
+        
         self.args.model_name = model_name
         self.args.model_type = model_type
 

--- a/simpletransformers/classification/classification_model.py
+++ b/simpletransformers/classification/classification_model.py
@@ -103,7 +103,7 @@ class ClassificationModel:
         use_cuda=True,
         cuda_device=-1,
         onnx_execution_provider=None,
-        normalization=False,
+        bertweet_normalization=False,
         **kwargs,
     ):
 
@@ -252,7 +252,7 @@ class ClassificationModel:
                 raise AttributeError("fp16 requires Pytorch >= 1.6. Please update Pytorch or turn off fp16.")
                 
         if model_name == 'vinai/bertweet-base':
-            self.tokenizer = tokenizer_class.from_pretrained(model_name, do_lower_case=self.args.do_lower_case, normalization=normalization, **kwargs)
+            self.tokenizer = tokenizer_class.from_pretrained(model_name, do_lower_case=self.args.do_lower_case, normalization=bertweet_normalization, **kwargs)
         else:
             self.tokenizer = tokenizer_class.from_pretrained(model_name, do_lower_case=self.args.do_lower_case, **kwargs)
         

--- a/simpletransformers/classification/classification_model.py
+++ b/simpletransformers/classification/classification_model.py
@@ -37,6 +37,7 @@ from transformers import (
     AlbertTokenizer,
     BertConfig,
     BertTokenizer,
+    BertweetTokenizer,
     CamembertConfig,
     CamembertTokenizer,
     DistilBertConfig,
@@ -123,6 +124,7 @@ class ClassificationModel:
         MODEL_CLASSES = {
             "albert": (AlbertConfig, AlbertForSequenceClassification, AlbertTokenizer),
             "bert": (BertConfig, BertForSequenceClassification, BertTokenizer),
+            "bertweet": (RobertaConfig, RobertaForSequenceClassification, BertweetTokenizer),
             "camembert": (CamembertConfig, CamembertForSequenceClassification, CamembertTokenizer),
             "distilbert": (DistilBertConfig, DistilBertForSequenceClassification, DistilBertTokenizer),
             "electra": (ElectraConfig, ElectraForSequenceClassification, ElectraTokenizer),


### PR DESCRIPTION
## What changed

For text classification:
- Add model, config and tokenizer. Associated BERTweet with `RobertaConfig`, following the merged PR on HF. 
- In case `model_name=='vinai/bertweet-base'`, assign the `bertweet_normalization` arg value to the `normalization` parameter of the tokenizer

## How to test

```python
from simpletransformers.classification import ClassificationModel
import pandas as pd
model = ClassificationModel('bertweet','vinai/bertweet-base',normalization=True)
df = pd.read_csv(path_to_csv_with_tweets)
df = df[['text','labels']]
model.train_model(df)
```

## Optional TO-DO:
- Include BERTweet for NER and other downstream tasks