### PR TITLE
Fix compatibility with different versions of wandb when sweeping

### DIFF
--- a/simpletransformers/classification/classification_model.py
+++ b/simpletransformers/classification/classification_model.py
@@ -80,6 +80,7 @@ from simpletransformers.classification.transformer_models.xlm_roberta_model impo
 from simpletransformers.classification.transformer_models.xlnet_model import XLNetForSequenceClassification
 from simpletransformers.config.global_args import global_args
 from simpletransformers.config.model_args import ClassificationArgs
+from simpletransformers.config.utils import sweep_config_to_sweep_values
 from simpletransformers.custom_models.models import ElectraForSequenceClassification
 
 try:
@@ -149,7 +150,7 @@ class ClassificationModel:
 
         if "sweep_config" in kwargs:
             sweep_config = kwargs.pop("sweep_config")
-            sweep_values = {key: value["value"] for key, value in sweep_config.as_dict().items() if key != "_wandb"}
+            sweep_values = sweep_config_to_sweep_values(sweep_config)
             self.args.update_from_dict(sweep_values)
 
         if self.args.manual_seed:

--- a/simpletransformers/classification/multi_label_classification_model.py
+++ b/simpletransformers/classification/multi_label_classification_model.py
@@ -33,6 +33,7 @@ from transformers import (
 from simpletransformers.classification import ClassificationModel
 from simpletransformers.config.global_args import global_args
 from simpletransformers.config.model_args import MultiLabelClassificationArgs
+from simpletransformers.config.utils import sweep_config_to_sweep_values
 from simpletransformers.custom_models.models import (
     AlbertForMultiLabelSequenceClassification,
     BertForMultiLabelSequenceClassification,
@@ -108,7 +109,7 @@ class MultiLabelClassificationModel(ClassificationModel):
 
         if "sweep_config" in kwargs:
             sweep_config = kwargs.pop("sweep_config")
-            sweep_values = {key: value["value"] for key, value in sweep_config.as_dict().items() if key != "_wandb"}
+            sweep_values = sweep_config_to_sweep_values(sweep_config)
             self.args.update_from_dict(sweep_values)
 
         if self.args.manual_seed:

--- a/simpletransformers/classification/multi_modal_classification_model.py
+++ b/simpletransformers/classification/multi_modal_classification_model.py
@@ -49,6 +49,7 @@ from simpletransformers.classification.classification_utils import (
 from simpletransformers.classification.transformer_models.mmbt_model import MMBTForClassification
 from simpletransformers.config.global_args import global_args
 from simpletransformers.config.model_args import MultiModalClassificationArgs
+from simpletransformers.config.utils import sweep_config_to_sweep_values
 
 try:
     import wandb
@@ -105,7 +106,7 @@ class MultiModalClassificationModel:
 
         if "sweep_config" in kwargs:
             sweep_config = kwargs.pop("sweep_config")
-            sweep_values = {key: value["value"] for key, value in sweep_config.as_dict().items() if key != "_wandb"}
+            sweep_values = sweep_config_to_sweep_values(sweep_config)
             self.args.update_from_dict(sweep_values)
 
         if self.args.manual_seed:

--- a/simpletransformers/config/utils.py
+++ b/simpletransformers/config/utils.py
@@ -1,0 +1,9 @@
+def sweep_config_to_sweep_values(sweep_config):
+    """
+    Converts an instance of wandb.Config to plain values map.
+
+    wandb.Config varies across versions quite significantly,
+    so we use the `keys` method that works consistently.
+    """
+
+    return {key: sweep_config[key] for key in sweep_config.keys()}

--- a/simpletransformers/conv_ai/conv_ai_model.py
+++ b/simpletransformers/conv_ai/conv_ai_model.py
@@ -47,6 +47,7 @@ from transformers import (
 from simpletransformers.classification.classification_utils import InputExample, convert_examples_to_features
 from simpletransformers.config.global_args import global_args
 from simpletransformers.config.model_args import ConvAIArgs
+from simpletransformers.config.utils import sweep_config_to_sweep_values
 from simpletransformers.conv_ai.conv_ai_utils import get_dataset
 
 try:
@@ -100,7 +101,7 @@ class ConvAIModel:
 
         if "sweep_config" in kwargs:
             sweep_config = kwargs.pop("sweep_config")
-            sweep_values = {key: value["value"] for key, value in sweep_config.as_dict().items() if key != "_wandb"}
+            sweep_values = sweep_config_to_sweep_values(sweep_config)
             self.args.update_from_dict(sweep_values)
 
         if self.args.manual_seed:

--- a/simpletransformers/language_generation/language_generation_model.py
+++ b/simpletransformers/language_generation/language_generation_model.py
@@ -29,6 +29,7 @@ from transformers import (
 
 from simpletransformers.config.global_args import global_args
 from simpletransformers.config.model_args import LanguageGenerationArgs
+from simpletransformers.config.utils import sweep_config_to_sweep_values
 from simpletransformers.language_generation.language_generation_utils import PREPROCESSING_FUNCTIONS
 
 logger = logging.getLogger(__name__)
@@ -71,7 +72,7 @@ class LanguageGenerationModel:
 
         if "sweep_config" in kwargs:
             sweep_config = kwargs.pop("sweep_config")
-            sweep_values = {key: value["value"] for key, value in sweep_config.as_dict().items() if key != "_wandb"}
+            sweep_values = sweep_config_to_sweep_values(sweep_config)
             self.args.update_from_dict(sweep_values)
 
         if self.args.manual_seed:

--- a/simpletransformers/language_modeling/language_modeling_model.py
+++ b/simpletransformers/language_modeling/language_modeling_model.py
@@ -69,6 +69,7 @@ from transformers.data.datasets.language_modeling import LineByLineTextDataset, 
 
 from simpletransformers.config.global_args import global_args
 from simpletransformers.config.model_args import LanguageModelingArgs
+from simpletransformers.config.utils import sweep_config_to_sweep_values
 from simpletransformers.custom_models.models import ElectraForLanguageModelingModel
 from simpletransformers.language_modeling.language_modeling_utils import SimpleDataset, mask_tokens
 
@@ -132,7 +133,7 @@ class LanguageModelingModel:
 
         if "sweep_config" in kwargs:
             sweep_config = kwargs.pop("sweep_config")
-            sweep_values = {key: value["value"] for key, value in sweep_config.as_dict().items() if key != "_wandb"}
+            sweep_values = sweep_config_to_sweep_values(sweep_config)
             self.args.update_from_dict(sweep_values)
 
         if self.args.manual_seed:

--- a/simpletransformers/language_representation/representation_model.py
+++ b/simpletransformers/language_representation/representation_model.py
@@ -13,6 +13,7 @@ import torch
 from transformers import BertConfig, BertTokenizer, GPT2Config, GPT2Tokenizer, RobertaConfig, RobertaTokenizer
 
 from simpletransformers.config.model_args import ModelArgs
+from simpletransformers.config.utils import sweep_config_to_sweep_values
 from simpletransformers.language_representation.transformer_models.bert_model import BertForTextRepresentation
 from simpletransformers.language_representation.transformer_models.gpt2_model import GPT2ForTextRepresentation
 
@@ -73,7 +74,7 @@ class RepresentationModel:
 
         if "sweep_config" in kwargs:
             sweep_config = kwargs.pop("sweep_config")
-            sweep_values = {key: value["value"] for key, value in sweep_config.as_dict().items() if key != "_wandb"}
+            sweep_values = sweep_config_to_sweep_values(sweep_config)
             self.args.update_from_dict(sweep_values)
 
         if self.args.manual_seed:

--- a/simpletransformers/ner/ner_model.py
+++ b/simpletransformers/ner/ner_model.py
@@ -60,6 +60,7 @@ from transformers.convert_graph_to_onnx import convert, quantize
 
 from simpletransformers.config.global_args import global_args
 from simpletransformers.config.model_args import NERArgs
+from simpletransformers.config.utils import sweep_config_to_sweep_values
 from simpletransformers.ner.ner_utils import (
     InputExample,
     LazyNERDataset,
@@ -125,7 +126,7 @@ class NERModel:
 
         if "sweep_config" in kwargs:
             sweep_config = kwargs.pop("sweep_config")
-            sweep_values = {key: value["value"] for key, value in sweep_config.as_dict().items() if key != "_wandb"}
+            sweep_values = sweep_config_to_sweep_values(sweep_config)
             self.args.update_from_dict(sweep_values)
 
         if self.args.manual_seed:

--- a/simpletransformers/question_answering/question_answering_model.py
+++ b/simpletransformers/question_answering/question_answering_model.py
@@ -65,6 +65,7 @@ from transformers import (
 
 from simpletransformers.config.global_args import global_args
 from simpletransformers.config.model_args import QuestionAnsweringArgs
+from simpletransformers.config.utils import sweep_config_to_sweep_values
 from simpletransformers.custom_models.models import ElectraForQuestionAnswering, XLMRobertaForQuestionAnswering
 from simpletransformers.question_answering.question_answering_utils import (
     LazyQuestionAnsweringDataset,
@@ -131,7 +132,7 @@ class QuestionAnsweringModel:
 
         if "sweep_config" in kwargs:
             sweep_config = kwargs.pop("sweep_config")
-            sweep_values = {key: value["value"] for key, value in sweep_config.as_dict().items() if key != "_wandb"}
+            sweep_values = sweep_config_to_sweep_values(sweep_config)
             self.args.update_from_dict(sweep_values)
 
         if self.args.manual_seed:

--- a/simpletransformers/seq2seq/seq2seq_model.py
+++ b/simpletransformers/seq2seq/seq2seq_model.py
@@ -58,6 +58,7 @@ from transformers import (
 
 from simpletransformers.config.global_args import global_args
 from simpletransformers.config.model_args import Seq2SeqArgs
+from simpletransformers.config.utils import sweep_config_to_sweep_values
 from simpletransformers.seq2seq.seq2seq_utils import Seq2SeqDataset, SimpleSummarizationDataset
 
 try:
@@ -139,7 +140,7 @@ class Seq2SeqModel:
 
         if "sweep_config" in kwargs:
             sweep_config = kwargs.pop("sweep_config")
-            sweep_values = {key: value["value"] for key, value in sweep_config.as_dict().items() if key != "_wandb"}
+            sweep_values = sweep_config_to_sweep_values(sweep_config)
             self.args.update_from_dict(sweep_values)
 
         if self.args.manual_seed:

--- a/simpletransformers/t5/t5_model.py
+++ b/simpletransformers/t5/t5_model.py
@@ -21,6 +21,7 @@ from transformers import AdamW, T5Config, T5ForConditionalGeneration, T5Tokenize
 
 from simpletransformers.config.global_args import global_args
 from simpletransformers.config.model_args import T5Args
+from simpletransformers.config.utils import sweep_config_to_sweep_values
 from simpletransformers.t5.t5_utils import T5Dataset
 
 try:
@@ -64,7 +65,7 @@ class T5Model:
 
         if "sweep_config" in kwargs:
             sweep_config = kwargs.pop("sweep_config")
-            sweep_values = {key: value["value"] for key, value in sweep_config.as_dict().items() if key != "_wandb"}
+            sweep_values = sweep_config_to_sweep_values(sweep_config)
             self.args.update_from_dict(sweep_values)
 
         if self.args.manual_seed:


### PR DESCRIPTION
Fixes #759.

I compared all versions of `wandb.Config` class listed in #759 and concluded that the `keys` method should work reliably for all of them.

Also, I've just installed `simpletransformers` from my branch and no longer experience the issue.