### PR TITLE
truncation=True in t5_utils

### DIFF
--- a/simpletransformers/t5/t5_utils.py
+++ b/simpletransformers/t5/t5_utils.py
@@ -26,18 +26,19 @@ def preprocess_data(data):
             max_length=args.max_seq_length,
             pad_to_max_length=True,
             return_tensors="pt",
+            truncation=True
         )
 
         target_text = tokenizer.encode(
-            target_text + " </s>", max_length=args.max_seq_length, pad_to_max_length=True, return_tensors="pt"
+            target_text + " </s>", max_length=args.max_seq_length, pad_to_max_length=True, return_tensors="pt", truncation=True
         )
     else:
         input_text = tokenizer.encode(
-            prefix + input_text, max_length=args.max_seq_length, pad_to_max_length=True, return_tensors="pt"
+            prefix + input_text, max_length=args.max_seq_length, pad_to_max_length=True, return_tensors="pt", truncation=True
         )
 
         target_text = tokenizer.encode(
-            target_text, max_length=args.max_seq_length, pad_to_max_length=True, return_tensors="pt"
+            target_text, max_length=args.max_seq_length, pad_to_max_length=True, return_tensors="pt", truncation=True
         )
     return (torch.flatten(input_text), torch.flatten(target_text))
 


### PR DESCRIPTION
In t5_utils.py **truncation should be True** for token encoding **when max_len is provided** in order avoid infinite warnings which crashes the colab notebook and notebook running on local machine although it runs fine on kaggle. 
Screenshot is attached [](url)
![Screenshot from 2020-10-16 06-28-20](https://user-images.githubusercontent.com/25720695/96200943-ebb60980-0f78-11eb-9320-dcd2dbe8a8ee.png)

[Notebook to reproduce the behavior, please run this on colab  or local machine.](https://colab.research.google.com/drive/1Zm83z29wFrRi03tQP4ZEky003vy-c4_X#scrollTo=1-GJELrbSZ15&uniqifier=1)  @ThilinaRajapakse 
