### PR TITLE
T5 update to handle different scenario

### DIFF
--- a/simpletransformers/t5/t5_model.py
+++ b/simpletransformers/t5/t5_model.py
@@ -91,7 +91,7 @@ class T5Model:
 
         self.results = {}
 
-        if model_name==None:
+        if model_name is None:
             self.config = config
             self.model = T5ForConditionalGeneration(config=self.config)
         else:

--- a/simpletransformers/t5/t5_model.py
+++ b/simpletransformers/t5/t5_model.py
@@ -111,8 +111,8 @@ class T5Model:
             self.args.fp16 = False
 
         self.args.model_type = "T5"
-        if model_name==None:
-            self.args.model_name = "T5fromScratch"
+        if model_name is None:
+            self.args.model_name = "T5_from_scratch"
         else:
             self.args.model_name = model_name
 

--- a/simpletransformers/t5/t5_model.py
+++ b/simpletransformers/t5/t5_model.py
@@ -92,7 +92,7 @@ class T5Model:
         self.results = {}
 
         if model_name is None:
-            self.config = config
+            self.config = self.args.config
             self.model = T5ForConditionalGeneration(config=self.config)
         else:
             self.config = T5Config.from_pretrained(model_name, **self.args.config)

--- a/simpletransformers/t5/t5_model.py
+++ b/simpletransformers/t5/t5_model.py
@@ -42,7 +42,7 @@ def chunks(lst, n):
 
 class T5Model:
     def __init__(
-        self, model_name=None, args=None, config=None, tokenizer=None, use_cuda=True, cuda_device=-1, **kwargs,
+        self, model_name, args=None, tokenizer=None, use_cuda=True, cuda_device=-1, **kwargs,
     ):
 
         """

--- a/simpletransformers/t5/t5_model.py
+++ b/simpletransformers/t5/t5_model.py
@@ -102,6 +102,7 @@ class T5Model:
             self.tokenizer = tokenizer
         else:
             self.tokenizer = T5Tokenizer.from_pretrained(model_name, truncate=True)
+        self.model.resize_token_embeddings(len(tokenizer))
 
         if self.args.dynamic_quantize:
             self.model = torch.quantization.quantize_dynamic(self.model, {torch.nn.Linear}, dtype=torch.qint8)


### PR DESCRIPTION
I propose to modify 1 argument and to add 2 arguments (optional) to the T5model class:
- model_name: becomes optional, if it is not set then T5 model without pre-trained weights is instantiated
- config: it has to be passed only if model_name is not provided (otherwise it is overwritten), it allows instantiating T5ForConditionalGeneration without passing a pre-trained model ([example](https://github.com/huggingface/transformers/issues/1714)) 
- tokenizer: optional, custom tokenizer to pass (it can be useful in case of, for example, additional tokens)