### PR TITLE
Update seq2seq_model.py

### DIFF
--- a/simpletransformers/seq2seq/seq2seq_model.py
+++ b/simpletransformers/seq2seq/seq2seq_model.py
@@ -844,7 +844,7 @@ class Seq2SeqModel:
             to_predict[i : i + self.args.eval_batch_size] for i in range(0, len(to_predict), self.args.eval_batch_size)
         ]:
             if self.args.model_type == "marian":
-                input_ids = self.encoder_tokenizer.prepare_translation_batch(
+                input_ids = self.encoder_tokenizer.prepare_seq2seq_batch(
                     batch,
                     max_length=self.args.max_seq_length,
                     padding="max_length",


### PR DESCRIPTION
Encountered an AttributeError with `model.predict()` when using a seq2seq marian model for translation: 'MarianTokenizer' object has no attribute 'prepare_translation_batch.

Checking into the Huggingface documentation, it looks like `prepare_translation_batch()` for marian models was renamed `prepare_seq2seq_batch()` in order to bring it in line with other seq2seq models in the library.

This update to seq2seq_model.py replaces `marian.prepare_translation_batch()` with `marian.prepare_seq2seq_batch()` to address this issue.