### PR TITLE
Update permalink to match that of `navigation.yml`

### DIFF
--- a/docs/_docs/35-convAI-minimal-start.md
+++ b/docs/_docs/35-convAI-minimal-start.md
@@ -1,6 +1,6 @@
 ---
 title: Conversational AI Examples
-permalink: /docs/convAI-examples/
+permalink: /docs/convAI-minimal-start/
 excerpt: "Conversational AI Examples"
 last_modified_at: 2020/10/15 23:16:38
 toc: true


### PR DESCRIPTION
Broken link: https://simpletransformers.ai/docs/convAI-minimal-start/
Works with: https://simpletransformers.ai/docs/convAI-examples/

Guided by consistency being king, I presume it was better to change the permalink than change the destination URL of the link.