### PR TITLE
Fixing WandB sweep issues by suppressing `wandb.init()` in `train()`

### DIFF
--- a/simpletransformers/classification/classification_model.py
+++ b/simpletransformers/classification/classification_model.py
@@ -538,6 +538,7 @@ class ClassificationModel:
 
         if args.wandb_project:
             if "sweep_config" not in kwargs:
+                logger.info(" Initializing WandB run.")
                 wandb.init(project=args.wandb_project, config={**asdict(args)}, **args.wandb_kwargs)
             wandb.watch(self.model)
 

--- a/simpletransformers/classification/classification_model.py
+++ b/simpletransformers/classification/classification_model.py
@@ -1008,11 +1008,10 @@ class ClassificationModel:
             for key in sorted(result.keys()):
                 writer.write("{} = {}\n".format(key, str(result[key])))
 
-        logger.info(f" DEBUG: project: {self.args.wandb_project}, wandb_log: {wandb_log}, multi_label: {multi_label}, self.args.regression: {self.args.regression}")
         if self.args.wandb_project and wandb_log and not multi_label and not self.args.regression:
-             #if not wandb.setup().settings.sweep_id:
-            logger.info(" Initializing WandB run for evaluation.")
-            wandb.init(project=args.wandb_project, config={**asdict(args)}, **args.wandb_kwargs)
+            if not wandb.setup().settings.sweep_id:
+                logger.info(" Initializing WandB run for evaluation.")
+                wandb.init(project=args.wandb_project, config={**asdict(args)}, **args.wandb_kwargs)
             if not args.labels_map:
                 self.args.labels_map = {i: i for i in range(self.num_labels)}
 

--- a/simpletransformers/classification/classification_model.py
+++ b/simpletransformers/classification/classification_model.py
@@ -538,7 +538,7 @@ class ClassificationModel:
 
         if args.wandb_project:
             if "sweep_config" not in kwargs:
-            wandb.init(project=args.wandb_project, config={**asdict(args)}, **args.wandb_kwargs)
+                wandb.init(project=args.wandb_project, config={**asdict(args)}, **args.wandb_kwargs)
             wandb.watch(self.model)
 
         if self.args.fp16:

--- a/simpletransformers/classification/classification_model.py
+++ b/simpletransformers/classification/classification_model.py
@@ -1008,6 +1008,7 @@ class ClassificationModel:
             for key in sorted(result.keys()):
                 writer.write("{} = {}\n".format(key, str(result[key])))
 
+        logger.info(f" DEBUG: project: {self.args.wandb_project}, wandb_log: {wandb_log}, multi_label: {multi_label}, self.args.regression: {self.args.regression}")
         if self.args.wandb_project and wandb_log and not multi_label and not self.args.regression:
              #if not wandb.setup().settings.sweep_id:
             logger.info(" Initializing WandB run for evaluation.")

--- a/simpletransformers/classification/classification_model.py
+++ b/simpletransformers/classification/classification_model.py
@@ -538,7 +538,7 @@ class ClassificationModel:
 
         if args.wandb_project:
             if not wandb.setup().settings.sweep_id:
-                logger.info(" Initializing WandB run.")
+                logger.info(" Initializing WandB run for training.")
                 wandb.init(project=args.wandb_project, config={**asdict(args)}, **args.wandb_kwargs)
             wandb.watch(self.model)
 
@@ -1009,6 +1009,8 @@ class ClassificationModel:
                 writer.write("{} = {}\n".format(key, str(result[key])))
 
         if self.args.wandb_project and wandb_log and not multi_label and not self.args.regression:
+             #if not wandb.setup().settings.sweep_id:
+            logger.info(" Initializing WandB run for evaluation.")
             wandb.init(project=args.wandb_project, config={**asdict(args)}, **args.wandb_kwargs)
             if not args.labels_map:
                 self.args.labels_map = {i: i for i in range(self.num_labels)}

--- a/simpletransformers/classification/classification_model.py
+++ b/simpletransformers/classification/classification_model.py
@@ -537,6 +537,7 @@ class ClassificationModel:
             training_progress_scores = self._create_training_progress_scores(multi_label, **kwargs)
 
         if args.wandb_project:
+            if "sweep_config" not in kwargs:
             wandb.init(project=args.wandb_project, config={**asdict(args)}, **args.wandb_kwargs)
             wandb.watch(self.model)
 

--- a/simpletransformers/classification/classification_model.py
+++ b/simpletransformers/classification/classification_model.py
@@ -537,7 +537,7 @@ class ClassificationModel:
             training_progress_scores = self._create_training_progress_scores(multi_label, **kwargs)
 
         if args.wandb_project:
-            if "sweep_config" not in kwargs:
+            if not wandb.setup().settings.sweep_id:
                 logger.info(" Initializing WandB run.")
                 wandb.init(project=args.wandb_project, config={**asdict(args)}, **args.wandb_kwargs)
             wandb.watch(self.model)


### PR DESCRIPTION
Doing WandB sweeps with `simpletransformers` seems to have some issues (#817, #545 and possibly more).
Some of these issues seem to be caused by the call to `wandb.init()` in the [train method](https://github.com/ThilinaRajapakse/simpletransformers/blob/0cf4ffcdf83ee339f657c10789542e892d3ba2b4/simpletransformers/classification/classification_model.py#L540).
For sweeps it is mandatory to already having called `wandb.init()` outside of the `simpletransformers` code, namely in the method that the sweep is looping over to create a number of runs in the sweep. We need to do this so we can pass `wandb.config` as the `sweep_config` parameter to create a `ClassificationModel`. Roughly like this:

```python
sweep_config = {...}
sweep_id = wandb.sweep(sweep_config, project="My Project")
model_args = {...}
def train():
    print("Starting train, initializing WandB.")
    wandb.init()
    model = ClassificationModel(
        architecture,
        modelname,
        use_cuda=True,
        cuda_device=0,
        sweep_config=wandb.config,
        args=model_args
    )
    print("Training model")
    model.train_model(
        train_df, eval_df=eval_df, acc=calcAcc
    )
    print("Finished training")
    wandb.join()
wandb.sweep(sweep_id, train)
```

When the above shown `train` method is called, `wandb.init()` creates a new run. But in a sub call of `model.train_model`, `wandb.init()` is called again as shown at the top. This causes the initial run to be stopped and a new one with the same ID (as I observed, at least) to be started which - for me and also others, as it seems - causes the wandb process to crash after a first training run, e.g.:

```
Waiting for W&B process to finish, PID 748
Program failed with code 1. Press ctrl-c to abort syncing.
```

To remedy this situation, I conditioned the call to `wandb.init()` in `simpletransformers#train()` on the non-presence of a sweep ID. Thus, when there is currently a sweep going on, no new run is initialized since we need to do this ourselves before anyway.
However, this means that we also need to pass the configuration to the `wandb.init(config=...)` call which changes the code skeleton above to

```python
sweep_config = {...}
sweep_id = wandb.sweep(sweep_config, project="My Project")
model_args = {...}
def train():
    print("Starting train, initializing WandB.")
    wandb.init(config=model_args)
    model = ClassificationModel(
        architecture,
        modelname,
        use_cuda=True,
        cuda_device=0,
        sweep_config=wandb.config,
        args=model_args
    )
    print("Training model")
    model.train_model(
        train_df, eval_df=eval_df, acc=calcAcc
    )
    print("Finished training")
    wandb.join()
wandb.sweep(sweep_id, train)
```

Please note the `wandb.init(config=model_args)` call which had no parameters before.
Doing it this way seems to solve the sweep issues for me and also metrics logging (#545) works for me.

I cannot say however, if my change causes issues in other scenarios. I would hope not since in all non-sweep cases the code should behave as it did previously, but I haven't tested much in this direction.