### PR TITLE
wrong_predictions eval and threshold in MultiLabelClassificationModel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ dmypy.json
 .pyre/
 #Stale Notebooks
 Untitled.ipynb
+
+# OSX
+.DS_Store

--- a/simpletransformers/classification/classification_model.py
+++ b/simpletransformers/classification/classification_model.py
@@ -1240,11 +1240,10 @@ class ClassificationModel:
 
         extra_metrics = {}
         for metric, func in kwargs.items():
-            if hasattr(func, '__call__'):
-                extra_metrics[metric] = func(labels, preds)
+            extra_metrics[metric] = func(labels, preds)
 
         if multi_label:
-            thrs = kwargs["threshold"] if "threshold" in kwargs else 0.5
+            thrs = self.args.threshold if self.args.threshold else 0.5
             if isinstance(thrs, list):
                 mismatched = labels != [
                     [self._threshold(pred, thrs[i]) for i, pred in enumerate(example)]


### PR DESCRIPTION
Fixes my issue #784 where I had two problems evaluating a MultiLabelClassificationModel

```python
model = MultiLabelClassificationModel()
result, model_outputs, wrong_predictions = model.eval_model(valid_df)
# wrong_predictions returns 100% of inputs
```

1. currently all inputs are returned as ```wrong_predictions``` because the line ```mismatched = labels != preds``` is run on the raw label probabilities, as [1, 0] != [0.8, 0]. Bug fix would compare the values after converting probabilities into 1 or 0, based on a threshold (default is 0.5)

```python
result, model_outputs, wrong_predictions = model.eval_model(valid_df, threshold=0.6)
# error, 'threshold' value 0.6 is not callable
```

2. we want send a custom threshold=0.6 in kwargs, and evaluate it before ```mismatched = labels != preds```. The code ```extra_metrics[metric] = func(labels, preds)``` tries to call all kwargs items as functions. I added an extra line so we won't call them unless it's a function.