### PR TITLE
Classification report for NER eval with 4 digits precision

### DIFF
--- a/simpletransformers/ner/ner_model.py
+++ b/simpletransformers/ner/ner_model.py
@@ -854,7 +854,7 @@ class NERModel:
         output_eval_file = os.path.join(eval_output_dir, "eval_results.txt")
         with open(output_eval_file, "w") as writer:
             if args.classification_report:
-                cls_report = classification_report(out_label_list, preds_list)
+                cls_report = classification_report(out_label_list, preds_list, digits=4)
                 writer.write("{}\n".format(cls_report))
             for key in sorted(result.keys()):
                 writer.write("{} = {}\n".format(key, str(result[key])))


### PR DESCRIPTION
I increased the digits precision for the NER evaluation to 4 digits (vs 2 of the previous version). This ensures to have a good final report that can be translated into percentages.