### PR TITLE
MBart predict function error

### DIFF
--- a/simpletransformers/seq2seq/seq2seq_model.py
+++ b/simpletransformers/seq2seq/seq2seq_model.py
@@ -925,6 +925,7 @@ class Seq2SeqModel:
                     max_length=self.args.max_seq_length,
                     pad_to_max_length=True,
                     padding="max_length",
+                    return_tensors="pt",
                     truncation=True,
                     src_lang=self.args.src_lang,
                 )["input_ids"]


### PR DESCRIPTION
Added missing argument 'return_tensors="pt",' to input_ids initialisation of mbart models. Using mbart for prediction before lead to "list has no to attribute" error.