### PR TITLE
Use args.silent when use_multiprocessing is False for NERModel

### DIFF
--- a/simpletransformers/ner/ner_utils.py
+++ b/simpletransformers/ner/ner_utils.py
@@ -347,7 +347,7 @@ def convert_examples_to_features(
             )
     else:
         features = []
-        for example in tqdm(examples):
+        for example in tqdm(examples, disable=silent):
             features.append(convert_example_to_feature(example))
     return features
 


### PR DESCRIPTION
args.silent was not used for converting the features of an NERModel when use_multiprocessing is set to false.

Thanks a lot for the hard work and the awesome library!