### PR TITLE
Add BERTweet for multilabel classification

### DIFF
--- a/simpletransformers/classification/multi_label_classification_model.py
+++ b/simpletransformers/classification/multi_label_classification_model.py
@@ -12,6 +12,7 @@ from transformers import (
     AlbertTokenizer,
     BertConfig,
     BertTokenizer,
+    BertweetTokenizer,
     CamembertConfig,
     CamembertTokenizer,
     DistilBertConfig,
@@ -39,6 +40,7 @@ from simpletransformers.config.utils import sweep_config_to_sweep_values
 from simpletransformers.custom_models.models import (
     AlbertForMultiLabelSequenceClassification,
     BertForMultiLabelSequenceClassification,
+    BertweetForMultiLabelSequenceClassification,
     CamembertForMultiLabelSequenceClassification,
     DistilBertForMultiLabelSequenceClassification,
     ElectraForMultiLabelSequenceClassification,
@@ -90,6 +92,7 @@ class MultiLabelClassificationModel(ClassificationModel):
         MODEL_CLASSES = {
             "albert": (AlbertConfig, AlbertForMultiLabelSequenceClassification, AlbertTokenizer,),
             "bert": (BertConfig, BertForMultiLabelSequenceClassification, BertTokenizer,),
+            "bertweet": (RobertaConfig, BertweetForMultiLabelSequenceClassification, BertweetTokenizer),
             "camembert": (CamembertConfig, CamembertForMultiLabelSequenceClassification, CamembertTokenizer,),
             "distilbert": (DistilBertConfig, DistilBertForMultiLabelSequenceClassification, DistilBertTokenizer,),
             "electra": (ElectraConfig, ElectraForMultiLabelSequenceClassification, ElectraTokenizer),

--- a/simpletransformers/custom_models/models.py
+++ b/simpletransformers/custom_models/models.py
@@ -126,6 +126,14 @@ class RobertaForMultiLabelSequenceClassification(BertPreTrainedModel):
 
         return outputs
 
+class BertweetForMultiLabelSequenceClassification(RobertaForMultiLabelSequenceClassification):
+    """
+    BERTweet model adapted for multi-label sequence classification.
+    BERTweet shares the Roberta architecture, so we can reuse the simpletransformers
+    RobertaForMultiLabelSequenceClassification implementation
+    """
+    base_model_prefix = "bertweet"
+
 
 class CamembertForMultiLabelSequenceClassification(RobertaForMultiLabelSequenceClassification):
     """
@@ -723,3 +731,4 @@ class ElectraForQuestionAnswering(ElectraPreTrainedModel):
 class XLMRobertaForQuestionAnswering(RobertaForQuestionAnswering):
     config_class = XLMRobertaConfig
     pretrained_model_archive_map = XLM_ROBERTA_PRETRAINED_MODEL_ARCHIVE_LIST
+


### PR DESCRIPTION
## What changed:
- Add BERTweet to multilabel classification (following #885 )

## How to test:

```python
from simpletransformers.classification import MultiLabelClassificationModel
import pandas as pd
import logging

# Train and Evaluation data needs to be in a Pandas Dataframe containing at least two columns, a 'text' and a 'labels' column. The `labels` column should contain multi-hot encoded lists.
train_data = [['Example sentence 1 for multilabel classification.', [1, 1, 1, 1, 0, 1]], ['This is another example sentence. ', [0, 1, 1, 0, 0, 0]]]
train_df = pd.DataFrame(train_data, columns=['text', 'labels'])


# Create a MultiLabelClassificationModel
model = MultiLabelClassificationModel('bertweet', 'vinai/bertweet-base', num_labels=6, args={'num_train_epochs': 5})

model.train_model(train_df)
```