### PR TITLE
Add special tokens to tokenizer through Args 

### DIFF
--- a/simpletransformers/classification/classification_model.py
+++ b/simpletransformers/classification/classification_model.py
@@ -278,6 +278,10 @@ class ClassificationModel:
                 model_name, do_lower_case=self.args.do_lower_case, **kwargs
             )
 
+        if self.args.special_tokens_list:
+            self.tokenizer.add_tokens(self.args.special_tokens_list)
+            self.model.resize_token_embeddings(len(self.tokenizer))    
+
         self.args.model_name = model_name
         self.args.model_type = model_type
 

--- a/simpletransformers/config/model_args.py
+++ b/simpletransformers/config/model_args.py
@@ -131,6 +131,7 @@ class ClassificationArgs(ModelArgs):
     model_class: str = "ClassificationModel"
     labels_list: list = field(default_factory=list)
     labels_map: dict = field(default_factory=dict)
+    special_tokens_list: list = field(default_factory=list)
     lazy_delimiter: str = "\t"
     lazy_labels_column: int = 1
     lazy_loading: bool = False


### PR DESCRIPTION
This PR makes it possible to add special additional tokens via ClassificationArgs . e.g for conversational AI applications one can add [USR] and [SYS] special tokens via a configuration like the following 
model = ClassificationModel('xlmroberta','xlm-roberta-base', num_labels=3, args={'special_tokens_list':["[USR]","[SYS]"]})
