### PR TITLE
Fixing prediction output for sliding_window=True and output_hidden_states=True

### DIFF
--- a/simpletransformers/classification/classification_model.py
+++ b/simpletransformers/classification/classification_model.py
@@ -1402,8 +1402,8 @@ class ClassificationModel:
                         )
                         all_embedding_outputs = embedding_outputs.detach().cpu().numpy()
                     else:
-                        # preds = np.append(preds, logits.detach().cpu().numpy(), axis=0)
-                        # out_label_ids = np.append(out_label_ids, inputs["labels"].detach().cpu().numpy(), axis=0)
+                        preds = np.append(preds, logits.detach().cpu().numpy(), axis=0)
+                        out_label_ids = np.append(out_label_ids, inputs["labels"].detach().cpu().numpy(), axis=0)
                         all_layer_hidden_states = np.append(
                             all_layer_hidden_states,
                             np.array([state.detach().cpu().numpy() for state in layer_hidden_states]),


### PR DESCRIPTION
Uncommenting these appends, which is necessary to generate the full set of predictions when `sliding_window=True`.