### PR TITLE
Add AUROC and AUPRC as default metrics for binary classification

### DIFF
--- a/simpletransformers/classification/classification_model.py
+++ b/simpletransformers/classification/classification_model.py
@@ -1600,6 +1600,8 @@ class ClassificationModel:
                     "mcc": [],
                     "train_loss": [],
                     "eval_loss": [],
+                    "auroc": [],
+                    "auprc": [],
                     **extra_metrics,
                 }
             elif self.model.num_labels == 1:


### PR DESCRIPTION
## What changed:
So far, the default metrics were threshold-specific (default=0.5). Now, they include non-threshold specific metrics for binary classification, namely the Area under the ROC curve (AUROC) and the Area under the Precision-Recall curve (AUPRC). This can come in handy when doing early stopping and mostly caring about AUROC.

## How to test:
To test, install my fork and run the following:

```python
from simpletransformers.classification import ClassificationModel, ClassificationArgs
import pandas as pd
import logging


logging.basicConfig(level=logging.INFO)
transformers_logger = logging.getLogger("transformers")
transformers_logger.setLevel(logging.WARNING)

# Preparing train data
train_data = [
    ["Aragorn was the heir of Isildur", 1],
    ["Frodo was the heir of Isildur", 0],
]
train_df = pd.DataFrame(train_data)
train_df.columns = ["text", "labels"]

# Preparing eval data
eval_data = [
    ["Theoden was the king of Rohan", 1],
    ["Merry was the king of Rohan", 0],
]
eval_df = pd.DataFrame(eval_data)
eval_df.columns = ["text", "labels"]

# Optional model configuration
model_args = ClassificationArgs(num_train_epochs=1)

# Create a ClassificationModel
model = ClassificationModel(
    "roberta", "roberta-base", args=model_args
)

# Train the model
model.train_model(train_df)

# Evaluate the model
result, model_outputs, wrong_predictions = model.eval_model(eval_df)

# Make predictions with the model
predictions, raw_outputs = model.predict(["Sam was a Wizard"])
```

The `result` dict should include the `auroc` and the `auprc` values. 
