### PR TITLE
Add special_tokens_list to LanguageGenerationArgs

### DIFF
--- a/simpletransformers/config/model_args.py
+++ b/simpletransformers/config/model_args.py
@@ -345,6 +345,7 @@ class LanguageGenerationArgs(ModelArgs):
     xlm_language: str = ""
     config_name: str = None
     tokenizer_name: str = None
+    special_tokens_list: list = field(default_factory=list)
 
 
 @dataclass


### PR DESCRIPTION
There is an issue initializing language generation models

```
from simpletransformers.language_generation import LanguageGenerationModel
model = LanguageGenerationModel("gpt2", "monsoon-nlp/sanaa")
> AttributeError: “LanguageGenerationArgs” object has no attributes “special_tokens_list”
```

The problem was introduced with commit 483e90ed950  which checks special_tokens_list in LanguageGenerationModel, but did not include it in the LanguageGenerationArgs class.

There are two other subclasses of ModelArgs which do not have special_tokens_list; I think they are unaffected, so we should add it to LanguageGenerationArgs only, and not on the ModelArgs level