### PR TITLE
fix mbart bug.

### DIFF
--- a/simpletransformers/seq2seq/seq2seq_model.py
+++ b/simpletransformers/seq2seq/seq2seq_model.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import torch
+import transformers
 from tensorboardX import SummaryWriter
 from torch.nn.utils.rnn import pad_sequence
 from torch.utils.data import DataLoader, Dataset, RandomSampler, SequentialSampler
@@ -77,6 +78,9 @@ try:
     wandb_available = True
 except ImportError:
     wandb_available = False
+
+if transformers.__version__ < '4.2.0':
+    MBartForConditionalGeneration._keys_to_ignore_on_save = []
 
 logger = logging.getLogger(__name__)
 

--- a/simpletransformers/seq2seq/seq2seq_utils.py
+++ b/simpletransformers/seq2seq/seq2seq_utils.py
@@ -6,15 +6,20 @@ from typing import Tuple
 
 import pandas as pd
 import torch
+import transformers
 from tokenizers.implementations import ByteLevelBPETokenizer
 from tokenizers.processors import BertProcessing
 from torch.utils.data import Dataset
 from tqdm.auto import tqdm
 from transformers import PreTrainedTokenizer
-from transformers.models.bart.modeling_bart import shift_tokens_right
+from transformers.models.bart.modeling_bart import shift_tokens_right as _shift_tokens_right
 
 logger = logging.getLogger(__name__)
 
+if transformers.__version__ < '4.2.0':
+    shift_tokens_right = lambda input_ids, pad_token_id, decoder_start_token_id: _shift_tokens_right(input_ids, pad_token_id)
+else:
+    shift_tokens_right = _shift_tokens_right
 
 def preprocess_data(data):
     input_text, target_text, encoder_tokenizer, decoder_tokenizer, args = data
@@ -107,7 +112,7 @@ def preprocess_data_mbart(data):
     )
 
     decoder_input_ids = tokenized_example["labels"].clone()
-    decoder_input_ids = shift_tokens_right(decoder_input_ids, tokenizer.pad_token_id)
+    decoder_input_ids = shift_tokens_right(decoder_input_ids, tokenizer.pad_token_id, tokenizer.lang_code_to_id[args.tgt_lang])
 
     labels = tokenized_example["labels"]
     labels[labels == tokenizer.pad_token_id] = -100


### PR DESCRIPTION
1. In transformers < 4.2.0, there is a bug in mbart model, 'model.encoder.embed_positions.weight' and 'model.decoder.embed_positions.weight' will not be saved. So in inference stage, the model is damaged.
2. The function "transformers.models.bart.modeling_bart.shift_tokens_right" has different interface in transformers >= 4.2.0.