### PR TITLE
Avoid removing label from original data

### DIFF
--- a/simpletransformers/classification/classification_utils.py
+++ b/simpletransformers/classification/classification_utils.py
@@ -160,7 +160,7 @@ class ClassificationDataset(Dataset):
         return len(self.examples)
 
     def __getitem__(self, index):
-        features = self.examples[index]
+        features = self.examples[index].copy()
         label = features.pop("label")
         if self.output_mode == "classification":
             label = torch.tensor(label, dtype=torch.long)


### PR DESCRIPTION
Fixes #972 

On the first training epoch, things work OK, but ```label = features.pop("label")``` removes the label from the original feature.  On the second epoch, we no longer can access the label.

By using dict.copy(), we avoid editing the original row