### PR TITLE
Fix bug when loading pretrained model on machine without GPU

### DIFF
--- a/simpletransformers/language_modeling/language_modeling_model.py
+++ b/simpletransformers/language_modeling/language_modeling_model.py
@@ -281,7 +281,9 @@ class LanguageModelingModel:
                         discriminator_config=self.discriminator_config,
                         **kwargs,
                     )
-                    self.model.load_state_dict(torch.load(os.path.join(self.args.model_name, "pytorch_model.bin")))
+                    self.model.load_state_dict(torch.load(os.path.join(self.args.model_name, "pytorch_model.bin"),
+                                                          map_location=self.device)
+                    )
             else:
                 self.model = model_class.from_pretrained(
                     model_name, config=self.config, cache_dir=self.args.cache_dir, **kwargs,


### PR DESCRIPTION
A possible fix for [this issue](https://github.com/ThilinaRajapakse/simpletransformers/issues/1002) regarding loading of models without GPU. This has been tested with an Electra model pretrained on GPU, as described on the issue.