### PR TITLE
Fix duplicate variable/unknown variable eval_df

### DIFF
--- a/docs/_docs/24-t5-specifics.md
+++ b/docs/_docs/24-t5-specifics.md
@@ -79,14 +79,14 @@ train_data = [
 train_df = pd.DataFrame(train_data)
 train_df.columns = ["prefix", "input_text", "target_text"]
 
-train_data = [
+eval_data = [
     ["binary classification", "Leia was Luke's sister" , 1],
     ["binary classification", "Han was a Sith Lord" , 0],
     ["generate question", "In 2020, the Star Wars franchise's total value was estimated at US$70 billion, and it is currently the fifth-highest-grossing media franchise of all time.", "What is the total value of the Star Wars franchise?"],
     ["generate question", "Leia was Luke's sister" , "Who was Luke's sister?"],
 ]
-train_df = pd.DataFrame(train_data)
-train_df.columns = ["prefix", "input_text", "target_text"]
+eval_df = pd.DataFrame(eval_data)
+eval_df.columns = ["prefix", "input_text", "target_text"]
 
 model_args = T5Args()
 model_args.num_train_epochs = 200


### PR DESCRIPTION
In the t5 specifics doc the train_data is copy-pasted twice but the second should be eval_data. 

Eval data is used at the bottom 

```
model.train_model(train_df, eval_data=eval_df, matches=count_matches)

print(model.eval_model(eval_df, matches=count_matches))
```

But had an unknown variable warning since it was never specified. 