### PR TITLE
fix incorrect data type for output label

### DIFF
--- a/docs/_docs/24-t5-specifics.md
+++ b/docs/_docs/24-t5-specifics.md
@@ -71,8 +71,8 @@ transformers_logger.setLevel(logging.WARNING)
 
 
 train_data = [
-    ["binary classification", "Anakin was Luke's father" , 1],
-    ["binary classification", "Luke was a Sith Lord" , 0],
+    ["binary classification", "Anakin was Luke's father" , "1"],
+    ["binary classification", "Luke was a Sith Lord" , "0"],
     ["generate question", "Star Wars is an American epic space-opera media franchise created by George Lucas, which began with the eponymous 1977 film and quickly became a worldwide pop-culture phenomenon", "Who created the Star Wars franchise?"],
     ["generate question", "Anakin was Luke's father" , "Who was Luke's father?"],
 ]
@@ -80,8 +80,8 @@ train_df = pd.DataFrame(train_data)
 train_df.columns = ["prefix", "input_text", "target_text"]
 
 train_data = [
-    ["binary classification", "Leia was Luke's sister" , 1],
-    ["binary classification", "Han was a Sith Lord" , 0],
+    ["binary classification", "Leia was Luke's sister" , "1"],
+    ["binary classification", "Han was a Sith Lord" , "0"],
     ["generate question", "In 2020, the Star Wars franchise's total value was estimated at US$70 billion, and it is currently the fifth-highest-grossing media franchise of all time.", "What is the total value of the Star Wars franchise?"],
     ["generate question", "Leia was Luke's sister" , "Who was Luke's sister?"],
 ]


### PR DESCRIPTION
In the t5 specifics doc, the labels for the binary classification class should be formatted as strings and not integers.
Using integers will raise:
```
ValueError: text input must of type `str` (single example), `List[str]` (batch or single pretokenized example) or `List[List[str]]` (batch of pretokenized examples).
```
Fixes #1147 