### PR TITLE
ONNX execution provider list fails when a fallback is specified

### DIFF
--- a/simpletransformers/ner/ner_model.py
+++ b/simpletransformers/ner/ner_model.py
@@ -280,7 +280,7 @@ class NERModel:
 
             if not onnx_execution_provider:
                 onnx_execution_provider = (
-                    "CUDAExecutionProvider" if use_cuda else "CPUExecutionProvider"
+                    ["CUDAExecutionProvider"] if use_cuda else ["CPUExecutionProvider"]
                 )
 
             options = SessionOptions()
@@ -288,12 +288,12 @@ class NERModel:
             if self.args.dynamic_quantize:
                 model_path = quantize(Path(os.path.join(model_name, "onnx_model.onnx")))
                 self.model = InferenceSession(
-                    model_path.as_posix(), options, providers=[onnx_execution_provider]
+                    model_path.as_posix(), options, providers=onnx_execution_provider
                 )
             else:
                 model_path = os.path.join(model_name, "onnx_model.onnx")
                 self.model = InferenceSession(
-                    model_path, options, providers=[onnx_execution_provider]
+                    model_path, options, providers=onnx_execution_provider
                 )
         else:
             if not self.args.quantized_model:


### PR DESCRIPTION
ONNX execution providers list fails when a fallback option is specified as an NERModel initialization parameter a tuple with fallback options.  E.g. ('CUDAExecutionProvider', 'CPUExecutionProvider').  The bug double wraps the list of providers causing the fallback to fail and ONNX InferenceSession method to fail.
