### PR TITLE
Rafactor classification model loss calculation

### DIFF
--- a/simpletransformers/classification/classification_model.py
+++ b/simpletransformers/classification/classification_model.py
@@ -634,18 +634,8 @@ class ClassificationModel:
         if self.loss_fct:
             logits = outputs[1]
             labels = inputs["labels"]
-            attention_mask = inputs.get("attention_mask")
-            if attention_mask is not None:
-                active_loss = attention_mask.view(-1) == 1
-                active_logits = logits.view(-1, self.num_labels)
-                active_labels = torch.where(
-                    active_loss,
-                    labels.view(-1),
-                    torch.tensor(self.loss_fct.ignore_index).type_as(labels),
-                )
-                loss = self.loss_fct(active_logits, active_labels)
-            else:
-                loss = self.loss_fct(logits.view(-1, self.num_labels), labels.view(-1))
+
+            loss = self.loss_fct(logits.view(-1, self.num_labels), labels.view(-1))
         return (loss, *outputs[1:])
 
     def train(

--- a/simpletransformers/classification/multi_label_classification_model.py
+++ b/simpletransformers/classification/multi_label_classification_model.py
@@ -200,6 +200,7 @@ class MultiLabelClassificationModel(ClassificationModel):
             self.config = config_class.from_pretrained(model_name, **self.args.config)
             self.num_labels = self.config.num_labels
         self.pos_weight = pos_weight
+        self.loss_fct = None
 
         if use_cuda:
             if torch.cuda.is_available():


### PR DESCRIPTION
This PR refactors loss calculation so this is identical to `NERModel`.

This PR makes `transformer_models` deprecated. 
Also I have changed import `from simpletransformers.custom_models.models import ElectraForSequenceClassification` to
`ElectraForSequenceClassification`, I am not entirely sure about what this change will bring (I actually think this is causing some issues with compatibility with transformers #571 )so this needs review @ThilinaRajapakse .

Other tan that I have added `losses` module, for future feature that I am working on. I have implemented part of in in my fork and different loss actually brings better performance (if you are interested in using focal loss now you can refer to: https://github.com/Zhylkaaa/simpletransformers/tree/dice_loss) 
