### PR TITLE
Small change to onnx batch_encode_plus to allow for pre-tokenized input

### DIFF
--- a/simpletransformers/ner/ner_model.py
+++ b/simpletransformers/ner/ner_model.py
@@ -1391,7 +1391,8 @@ class NERModel:
 
             # Encode
             model_inputs = self.tokenizer.batch_encode_plus(
-                to_predict, return_tensors="pt", padding=True, truncation=True
+                to_predict, return_tensors="pt", padding=True, truncation=True,
+                is_split_into_words=not split_on_space
             )
 
             # Change shape for batching


### PR DESCRIPTION
Based on the value of split_on_space, when using onnx, include an option in batch_encode_plus to allow for pretokenized input.