### PR TITLE
Fixes unbound local error in ner_utils.py

### DIFF
--- a/simpletransformers/ner/ner_utils.py
+++ b/simpletransformers/ner/ner_utils.py
@@ -711,10 +711,10 @@ class LazyNERDataset(Dataset):
             else:
                 # Examples could have no label for mode = "test"
                 labels.append("O")
-        if words:
-            example = InputExample(
-                guid="%s-%d".format("train", idx), words=words, labels=labels
-            )
+
+        example = InputExample(
+            guid="%s-%d".format("train", idx), words=words, labels=labels
+        )
 
         label_map = {label: i for i, label in enumerate(self.args.labels_list)}
 


### PR DESCRIPTION
Fixes ==> UnboundLocalError: local variable 'example' referenced before assignment
Mostly happens during eval.

<module>
    dev_result, dev_model_outputs, dev_predictions = best_model.eval_model(eval_data=dev_file_clean)
  File "/opt/anaconda3/envs/st2/lib/python3.9/site-packages/simpletransformers/ner/ner_model.py", line 1146, in eval_model
    result, model_outputs, preds_list = self.evaluate(
  File "/opt/anaconda3/envs/st2/lib/python3.9/site-packages/simpletransformers/ner/ner_model.py", line 1200, in evaluate
    for batch in tqdm(
  File "/opt/anaconda3/envs/st2/lib/python3.9/site-packages/tqdm/std.py", line 1185, in __iter__
    for obj in iterable:
  File "/opt/anaconda3/envs/st2/lib/python3.9/site-packages/torch/utils/data/dataloader.py", line 521, in __next__
    data = self._next_data()
  File "/opt/anaconda3/envs/st2/lib/python3.9/site-packages/torch/utils/data/dataloader.py", line 561, in _next_data
    data = self._dataset_fetcher.fetch(index)  # may raise StopIteration
  File "/opt/anaconda3/envs/st2/lib/python3.9/site-packages/torch/utils/data/_utils/fetch.py", line 44, in fetch
    data = [self.dataset[idx] for idx in possibly_batched_index]
  File "/opt/anaconda3/envs/st2/lib/python3.9/site-packages/torch/utils/data/_utils/fetch.py", line 44, in <listcomp>
    data = [self.dataset[idx] for idx in possibly_batched_index]
  File "/opt/anaconda3/envs/st2/lib/python3.9/site-packages/simpletransformers/ner/ner_utils.py", line 722, in __getitem__
    example,
UnboundLocalError: local variable 'example' referenced before assignment
