### PR TITLE
fix customized weights bug for ner model

### DIFF
--- a/simpletransformers/ner/ner_model.py
+++ b/simpletransformers/ner/ner_model.py
@@ -287,7 +287,7 @@ class NERModel:
         else:
             self.device = "cpu"
 
-        if self.weight:
+        if self.weight != None:
             self.loss_fct = CrossEntropyLoss(
                 weight=torch.Tensor(self.weight).to(self.device)
             )

--- a/simpletransformers/ner/ner_model.py
+++ b/simpletransformers/ner/ner_model.py
@@ -287,7 +287,7 @@ class NERModel:
         else:
             self.device = "cpu"
 
-        if self.weight != None:
+        if self.weight is not None:
             self.loss_fct = CrossEntropyLoss(
                 weight=torch.Tensor(self.weight).to(self.device)
             )


### PR DESCRIPTION
```python
model = NERModel(
    "roberta", 
    "roberta-base", 
    weight = torch.tensor([0.001, 1.0000]),
    args=model_args,
)
```
 Adding customized weights for NER model leads to this bug
```bash
Traceback (most recent call last):
  File "/home/vul337/electra-for-aida/finetune.py", line 79, in <module>
    model = NERModel(
  File "/home/vul337/miniconda3/envs/st/lib/python3.9/site-packages/simpletransformers/ner/ner_model.py", line 290, in __init__
    if self.weight:
RuntimeError: Boolean value of Tensor with more than one value is ambiguous
```