### PR TITLE
Language modeling sentence piece bugfix

### DIFF
--- a/simpletransformers/language_modeling/language_modeling_model.py
+++ b/simpletransformers/language_modeling/language_modeling_model.py
@@ -1129,13 +1129,13 @@ class LanguageModelingModel:
                 # XLMRoberta uses sentencepiece.bpe as a vocab model prefix
                 prefix='sentencepiece.bpe'
                 spm.SentencePieceTrainer.Train(
-                    f"--input={files} --user_defined_symbols='<mask>,<s>NOTUSED,</s>NOTUSED' --model_prefix={prefix} --vocab_size={self.args.vocab_size}")
+                    f"--input={files} --user_defined_symbols='<mask>,<s>NOTUSED,</s>NOTUSED' --model_prefix={prefix} --vocab_size={self.args.vocab_size - 2 }")
             else:
                 # </s>,<s>,<unk>,<pad> are built in -- leave as default
                 # BigBird uses spiece as a vocab model prefix
                 prefix = 'spiece'
                 spm.SentencePieceTrainer.Train(
-                    f"--input={files} --user_defined_symbols='[SEP],[CLS],[MASK]' --model_prefix=spiece --vocab_size={self.args.vocab_size}")
+                    f"--input={files} --user_defined_symbols='[SEP],[CLS],[MASK]' --model_prefix=spiece --vocab_size={self.args.vocab_size - 3}")
 
             # SentencePiece There is no option for output path https://github.com/google/sentencepiece/blob/master/doc/options.md
             if os.path.exists(output_dir + '/' + f'{prefix}.model'):

--- a/simpletransformers/language_modeling/language_modeling_model.py
+++ b/simpletransformers/language_modeling/language_modeling_model.py
@@ -1129,7 +1129,7 @@ class LanguageModelingModel:
                 # XLMRoberta uses sentencepiece.bpe as a vocab model prefix
                 prefix='sentencepiece.bpe'
                 spm.SentencePieceTrainer.Train(
-                    f"--input={files} --user_defined_symbols='<mask>,<s>NOTUSED,</s>NOTUSED' --model_prefix={prefix} --vocab_size={self.args.vocab_size - 2 }")
+                    f"--input={files} --user_defined_symbols='<mask>,<s>NOTUSED,</s>NOTUSED' --model_prefix={prefix} --vocab_size={self.args.vocab_size - 2}")
             else:
                 # </s>,<s>,<unk>,<pad> are built in -- leave as default
                 # BigBird uses spiece as a vocab model prefix

--- a/simpletransformers/ner/ner_utils.py
+++ b/simpletransformers/ner/ner_utils.py
@@ -280,12 +280,15 @@ def convert_example_to_feature(
                 word_tokens = tokenizer.tokenize(word)
             else:
                 word_tokens = example.tokenized_word_ids[i]
-            tokens.extend(word_tokens)
             # Use the real label id for the first token of the word, and padding ids for the remaining tokens
             if word_tokens:  # avoid non printable character like '\u200e' which are tokenized as a void token ''
-                label_ids.extend(
-                    [label_map[label]] + [pad_token_label_id] * (len(word_tokens) - 1)
-                )
+                tokens.extend(word_tokens)
+            else:
+                word_tokens = tokenizer.tokenize(tokenizer.unk_token)
+                tokens.extend(word_tokens)
+            label_ids.extend(
+                [label_map[label]] + [pad_token_label_id] * (len(word_tokens) - 1)
+            )
 
     # Account for [CLS] and [SEP] with "- 2" and with "- 3" for RoBERTa.
     special_tokens_count = 3 if sep_token_extra else 2

--- a/simpletransformers/ner/ner_utils.py
+++ b/simpletransformers/ner/ner_utils.py
@@ -711,10 +711,10 @@ class LazyNERDataset(Dataset):
             else:
                 # Examples could have no label for mode = "test"
                 labels.append("O")
-        if words:
-            example = InputExample(
-                guid="%s-%d".format("train", idx), words=words, labels=labels
-            )
+
+        example = InputExample(
+            guid="%s-%d".format("train", idx), words=words, labels=labels
+        )
 
         label_map = {label: i for i, label in enumerate(self.args.labels_list)}
 


### PR DESCRIPTION
Required user defined tokens for XLMRoberta  and SentencePiece pretrained models were not accounted for in the vocabulary size.  Subsequently, the config.json vocab_size was off by 2 for XLMRoberta and 3 for BigBird.

This can be manually fixed for any existing trained models by manually editing the config.json