### PR TITLE
Added `wandb.run.id` to model attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ dmypy.json
 .pyre/
 #Stale Notebooks
 Untitled.ipynb
+
+# pycharm folders
+.idea

--- a/simpletransformers/classification/classification_model.py
+++ b/simpletransformers/classification/classification_model.py
@@ -876,6 +876,7 @@ class ClassificationModel:
                     **args.wandb_kwargs,
                 )
                 wandb.run._label(repo="simpletransformers")
+                self.wandb_run_id = wandb.run.id
             wandb.watch(self.model)
 
         if self.args.fp16:

--- a/simpletransformers/classification/multi_modal_classification_model.py
+++ b/simpletransformers/classification/multi_modal_classification_model.py
@@ -573,6 +573,7 @@ class MultiModalClassificationModel:
             )
             wandb.run._label(repo="simpletransformers")
             wandb.watch(self.model)
+            self.wandb_run_id = wandb.run.id
 
         if args.fp16:
             from torch.cuda import amp

--- a/simpletransformers/conv_ai/conv_ai_model.py
+++ b/simpletransformers/conv_ai/conv_ai_model.py
@@ -475,6 +475,7 @@ class ConvAIModel:
             )
             wandb.run._label(repo="simpletransformers")
             wandb.watch(self.model)
+            self.wandb_run_id = wandb.run.id
 
         if args.fp16:
             from torch.cuda import amp

--- a/simpletransformers/language_modeling/language_modeling_model.py
+++ b/simpletransformers/language_modeling/language_modeling_model.py
@@ -620,6 +620,7 @@ class LanguageModelingModel:
             wandb.init(project=args.wandb_project, config={**asdict(args)}, **args.wandb_kwargs)
             wandb.run._label(repo="simpletransformers")
             wandb.watch(self.model)
+            self.wandb_run_id = wandb.run.id
 
         if args.fp16:
             from torch.cuda import amp

--- a/simpletransformers/ner/ner_model.py
+++ b/simpletransformers/ner/ner_model.py
@@ -713,6 +713,7 @@ class NERModel:
             )
             wandb.run._label(repo="simpletransformers")
             wandb.watch(self.model)
+            self.wandb_run_id = wandb.run.id
 
         if self.args.fp16:
             from torch.cuda import amp

--- a/simpletransformers/question_answering/question_answering_model.py
+++ b/simpletransformers/question_answering/question_answering_model.py
@@ -260,6 +260,7 @@ class QuestionAnsweringModel:
         self.args.model_name = model_name
         self.args.model_type = model_type
 
+        self.wandb_run_id = None
         if self.args.wandb_project and not wandb_available:
             warnings.warn(
                 "wandb_project specified but wandb is not available. Wandb disabled."
@@ -687,6 +688,7 @@ class QuestionAnsweringModel:
             )
             wandb.run._label(repo="simpletransformers")
             wandb.watch(self.model)
+            self.wandb_run_id = wandb.run.id
 
         if args.fp16:
             from torch.cuda import amp

--- a/simpletransformers/seq2seq/seq2seq_model.py
+++ b/simpletransformers/seq2seq/seq2seq_model.py
@@ -707,6 +707,7 @@ class Seq2SeqModel:
             )
             wandb.run._label(repo="simpletransformers")
             wandb.watch(self.model)
+            self.wandb_run_id = wandb.run.id
 
         if args.fp16:
             from torch.cuda import amp

--- a/simpletransformers/t5/t5_model.py
+++ b/simpletransformers/t5/t5_model.py
@@ -486,6 +486,7 @@ class T5Model:
             )
             wandb.run._label(repo="simpletransformers")
             wandb.watch(self.model)
+            self.wandb_run_id = wandb.run.id
 
         if args.fp16:
             from torch.cuda import amp


### PR DESCRIPTION
This PR adds a new attribute `wandb_run_id` to the models, this allows users to grab the run id after the training is finished and use it to extend the current logging features provided.