### PR TITLE
Use eval_file if it is defined in train_model()

### DIFF
--- a/simpletransformers/conv_ai/conv_ai_model.py
+++ b/simpletransformers/conv_ai/conv_ai_model.py
@@ -265,7 +265,9 @@ class ConvAIModel:
 
         if self.args.evaluate_during_training:
             eval_loader, eval_sampler = self.load_and_cache_examples(
-                verbose=verbose, evaluate=True
+                dataset_path=eval_file,
+                verbose=verbose, evaluate=True,
+                no_cache=self.args.no_cache or self.args.reprocess_input_data
             )
         else:
             eval_loader = None


### PR DESCRIPTION
Hi Thilina,
the function ConvAIModel.train_model() has eval_file as its parameter, but it is not used when it tries to load the dataset for the evaluation even it is defined, instead it uses the default dataset (PERSONACHAT_URL).