### PR TITLE
Fix bug: dictionary requires unpacking

### DIFF
--- a/simpletransformers/classification/classification_model.py
+++ b/simpletransformers/classification/classification_model.py
@@ -1019,7 +1019,7 @@ class ClassificationModel:
 
                         for key, value in flatten_results(
                             self._get_last_metrics(training_progress_scores)
-                        ):
+                        ).items():
                             try:
                                 tb_writer.add_scalar(key, value, global_step)
                             except (NotImplementedError, AssertionError):
@@ -1180,7 +1180,7 @@ class ClassificationModel:
 
                 for key, value in flatten_results(
                     self._get_last_metrics(training_progress_scores)
-                ):
+                ).items():
                     try:
                         tb_writer.add_scalar(key, value, global_step)
                     except (NotImplementedError, AssertionError):


### PR DESCRIPTION
This fixed a bug that causes "model.train_model(train_df, eval_df=eval_df)" to throw an exception when using a classification model.