### PR TITLE
Bugfix for SentencePiece trainer

### DIFF
--- a/simpletransformers/language_modeling/language_modeling_model.py
+++ b/simpletransformers/language_modeling/language_modeling_model.py
@@ -1442,14 +1442,14 @@ class LanguageModelingModel:
                 # XLMRoberta uses sentencepiece.bpe as a vocab model prefix
                 prefix = "sentencepiece.bpe"
                 spm.SentencePieceTrainer.Train(
-                    f"--input={files} --user_defined_symbols='<mask>,<s>NOTUSED,</s>NOTUSED' --model_prefix={prefix} --vocab_size={self.args.vocab_size - 2}"
+                    f"--input={files} --user_defined_symbols=<mask>,<s>NOTUSED,</s>NOTUSED --model_prefix={prefix} --vocab_size={self.args.vocab_size - 2}"
                 )
             else:
                 # </s>,<s>,<unk>,<pad> are built in -- leave as default
                 # BigBird uses spiece as a vocab model prefix
                 prefix = "spiece"
                 spm.SentencePieceTrainer.Train(
-                    f"--input={files} --user_defined_symbols='[SEP],[CLS],[MASK]' --model_prefix=spiece --vocab_size={self.args.vocab_size - 3}"
+                    f"--input={files} --user_defined_symbols=[SEP],[CLS],[MASK] --model_prefix=spiece --vocab_size={self.args.vocab_size - 3}"
                 )
 
             # SentencePiece There is no option for output path https://github.com/google/sentencepiece/blob/master/doc/options.md


### PR DESCRIPTION
Quotes around user_defined_symbols are required If running sentencepiece trainer from the command line
As of, not sure when, when calling the sentencepiece trainer via the api, the quotes are added to the first and last symbol
This fix corrects the vocabulary generation for downstream tasks
@ThilinaRajapakse this is a fairly urgent pull request