### PR TITLE
bugfix for pre-tokenized onnx predict

### DIFF
--- a/simpletransformers/ner/ner_model.py
+++ b/simpletransformers/ner/ner_model.py
@@ -1448,7 +1448,7 @@ class NERModel:
 
             # Encode
             model_inputs = self.tokenizer.batch_encode_plus(
-                to_predict, return_tensors="pt", padding=True, truncation=True
+                to_predict, return_tensors="pt", padding=True, truncation=True, is_split_into_words=(not split_on_space)
             )
 
             # Change shape for batching


### PR DESCRIPTION
@ThilinaRajapakse if split_on_spaces is false and the input is pre-tokenized, tokenizer.batch_encode_plus now requires a parameter to process the input data.