### PR TITLE
Fix wrong order of model classes for key auto in question answering

### DIFF
--- a/simpletransformers/question_answering/question_answering_model.py
+++ b/simpletransformers/question_answering/question_answering_model.py
@@ -132,7 +132,7 @@ class QuestionAnsweringModel:
 
         MODEL_CLASSES = {
             "albert": (AlbertConfig, AlbertForQuestionAnswering, AlbertTokenizer),
-            "auto": (AutoConfig, AutoTokenizer, AutoModelForQuestionAnswering),
+            "auto": (AutoConfig, AutoModelForQuestionAnswering, AutoTokenizer),
             "bart": (BartConfig, BartForQuestionAnswering, BartTokenizer),
             "bert": (BertConfig, BertForQuestionAnswering, BertTokenizer),
             "camembert": (


### PR DESCRIPTION
In question_answering_model.py, the classes in MODEL_CLASSES for key 'auto' are in the wrong order. It should be config, model, tokenizer.