### PR TITLE
fixed NER onnx support

### DIFF
--- a/simpletransformers/ner/ner_model.py
+++ b/simpletransformers/ner/ner_model.py
@@ -1509,16 +1509,22 @@ class NERModel:
                     )
 
             pad_token_label_id = -100
-            out_label_ids = []
-            for word in to_predict[0].split():
-                word_tokens = self.tokenizer.tokenize(word)
+            out_label_ids = [[] for _ in range(len(to_predict))]
+            max_len = len(out_input_ids[0])
 
-                out_label_ids.extend(
+            for index, sentence in enumerate(to_predict):
+                for word in sentence.split():
+                    word_tokens = self.tokenizer.tokenize(word)
+                    out_label_ids[index].extend(
                     [0] + [pad_token_label_id] * (len(word_tokens) - 1)
                 )
-            out_label_ids.insert(0, -100)
-            out_label_ids.append(-100)
-            out_label_ids = np.array(out_label_ids).reshape(1, len(out_label_ids))
+                out_label_ids[index].insert(0,pad_token_label_id)
+                out_label_ids[index].append(pad_token_label_id)
+
+                if len(out_label_ids[index]) < max_len:
+                    out_label_ids[index].extend([-100] * (max_len-len(out_label_ids[index])))
+
+            out_label_ids = np.array(out_label_ids).reshape(len(out_label_ids), max_len)
         else:
 
             eval_dataset = self.load_and_cache_examples(

--- a/simpletransformers/ner/ner_model.py
+++ b/simpletransformers/ner/ner_model.py
@@ -1507,10 +1507,18 @@ class NERModel:
                     out_attention_mask = np.append(
                         out_attention_mask, inputs_onnx["attention_mask"], axis=0
                     )
-            out_label_ids = np.zeros_like(out_input_ids)
-            for index in range(len(out_label_ids)):
-                out_label_ids[index][0] = -100
-                out_label_ids[index][-1] = -100
+
+            pad_token_label_id = -100
+            out_label_ids = []
+            for word in to_predict[0].split():
+                word_tokens = self.tokenizer.tokenize(word)
+
+                out_label_ids.extend(
+                    [0] + [pad_token_label_id] * (len(word_tokens) - 1)
+                )
+            out_label_ids.insert(0, -100)
+            out_label_ids.append(-100)
+            out_label_ids = np.array(out_label_ids).reshape(1, len(out_label_ids))
         else:
 
             eval_dataset = self.load_and_cache_examples(


### PR DESCRIPTION
After going through the code I observed.
1. For the PyTorch model, if a word is split using tokenization (Eg: running - run + ##ning) then except for the first index everything (in that split token) is -100 in out_label_ids.
2. For the ONNX Model, only the first and last index values in out_label_ids were -100 because they were CLS and SEP.

So, I copied some code from PyTorch prediction and make some changes to make it work for ONNX.
However, it is only tested for a Single Prediction. 