### PR TITLE
XLMRoberta sentencepiece special token bugfix

### DIFF
--- a/simpletransformers/language_modeling/language_modeling_model.py
+++ b/simpletransformers/language_modeling/language_modeling_model.py
@@ -1441,15 +1441,15 @@ class LanguageModelingModel:
                 # </s>,<s>,<unk>,<pad> are built in -- leave as default
                 # XLMRoberta uses sentencepiece.bpe as a vocab model prefix
                 prefix = "sentencepiece.bpe"
-                self.args.special_tokens = []
+                self.args.special_tokens = ["<s>","</s>","<pad>","<mask>","<s>NOTUSED","</s>NOTUSED"]
                 spm.SentencePieceTrainer.Train(
-                    f"--input={files} --user_defined_symbols='<pad>,<mask>,<s>NOTUSED,</s>NOTUSED' --model_type=bpe --model_prefix={prefix} --vocab_size={self.args.vocab_size} --shuffle_input_sentence=true --max_sentence_length=10000"
+                    f"--input={files} --user_defined_symbols=<pad>,<mask>,<s>NOTUSED,</s>NOTUSED --model_type=bpe --model_prefix={prefix} --vocab_size={self.args.vocab_size - 2} --shuffle_input_sentence=true --max_sentence_length=10000"
                 )
             else:
                 # </s>,<s>,<unk>,<pad> are built in -- leave as default
                 # BigBird uses spiece as a vocab model prefix
                 prefix = "spiece"
-                self.args.special_tokens = []
+                self.args.special_tokens = ['<s>','</s>','<pad>','[SEP]','[CLS]','[MASK]']
                 spm.SentencePieceTrainer.Train(
                     f"--input={files} --user_defined_symbols=<pad>,[SEP],[CLS],[MASK] --model_type=bpe --model_prefix=spiece --vocab_size={self.args.vocab_size} --shuffle_input_sentence=true --max_sentence_length=10000" 
                 )

--- a/simpletransformers/language_modeling/language_modeling_model.py
+++ b/simpletransformers/language_modeling/language_modeling_model.py
@@ -25,7 +25,7 @@ from sklearn.metrics import (
 )
 from torch.utils.tensorboard import SummaryWriter
 from tokenizers import BertWordPieceTokenizer, ByteLevelBPETokenizer
-from tokenizers.implementations import SentencePieceBPETokenizer
+from tokenizers.implementations import SentencePieceBPETokenizer, SentencePieceUnigramTokenizer
 from tokenizers.processors import BertProcessing
 from torch.nn.utils.rnn import pad_sequence
 from torch.utils.data import DataLoader, Dataset, RandomSampler, SequentialSampler
@@ -1349,7 +1349,7 @@ class LanguageModelingModel:
                 )
                 if (
                     self.args.max_seq_length > 509
-                    and self.args.model_type != "longformer"
+                    and self.args.model_type not in ["longformer", "bigbird"]
                 ):
                     self.args.max_seq_length = (
                         509
@@ -1441,15 +1441,17 @@ class LanguageModelingModel:
                 # </s>,<s>,<unk>,<pad> are built in -- leave as default
                 # XLMRoberta uses sentencepiece.bpe as a vocab model prefix
                 prefix = "sentencepiece.bpe"
+                self.args.special_tokens = []
                 spm.SentencePieceTrainer.Train(
-                    f"--input={files} --user_defined_symbols=<mask>,<s>NOTUSED,</s>NOTUSED --model_prefix={prefix} --vocab_size={self.args.vocab_size - 2}"
+                    f"--input={files} --user_defined_symbols='<pad>,<mask>,<s>NOTUSED,</s>NOTUSED' --model_type=bpe --model_prefix={prefix} --vocab_size={self.args.vocab_size} --shuffle_input_sentence=true --max_sentence_length=10000"
                 )
             else:
                 # </s>,<s>,<unk>,<pad> are built in -- leave as default
                 # BigBird uses spiece as a vocab model prefix
                 prefix = "spiece"
+                self.args.special_tokens = []
                 spm.SentencePieceTrainer.Train(
-                    f"--input={files} --user_defined_symbols=[SEP],[CLS],[MASK] --model_prefix=spiece --vocab_size={self.args.vocab_size - 3}"
+                    f"--input={files} --user_defined_symbols=<pad>,[SEP],[CLS],[MASK] --model_type=bpe --model_prefix=spiece --vocab_size={self.args.vocab_size} --shuffle_input_sentence=true --max_sentence_length=10000" 
                 )
 
             # SentencePiece There is no option for output path https://github.com/google/sentencepiece/blob/master/doc/options.md


### PR DESCRIPTION
I removed the extra quotes in the sentencepiece trainer parameters for XLMRoberta language models special tokens. I had done this before for bigbird.
Removed the bigbird -3 vocabulary size adjustment, after Dec 28th sentencepiece update this is no longer necessary.