### PR TITLE
ner_utils lazy_loading_start_line default injects unigram into first sample

### DIFF
--- a/simpletransformers/ner/ner_utils.py
+++ b/simpletransformers/ner/ner_utils.py
@@ -680,7 +680,7 @@ class LazyNERDataset(Dataset):
     def __init__(self, data_file, tokenizer, args):
         self.data_file = data_file
         self.lazy_loading_start_line = (
-            args.lazy_loading_start_line if args.lazy_loading_start_line else 0
+            args.lazy_loading_start_line if args.lazy_loading_start_line else 1
         )
         self.example_lines, self.num_entries = self._get_examples(
             self.data_file, self.lazy_loading_start_line


### PR DESCRIPTION
linecache is 1 relative not 0.  
The PR fixes the first sample being prepended with an empty unigram. Subsequently the unigram causes a one unigram shift as compared to the original data and labels.
Affects NER training and eval.
Workaround is to set args.lazy_loading_start_line=1 until this bugfix is merged.