### PR TITLE
Bugs related to lazy loading

### DIFF
--- a/examples/text_classification/lazy_loading_regression.py
+++ b/examples/text_classification/lazy_loading_regression.py
@@ -37,6 +37,7 @@ train_args = {
     "lazy_labels_column": 2,
     "lazy_header_row": True,
     "regression": True,
+    "lazy_loading": True,
 }
 
 # Create a TransformerModel

--- a/simpletransformers/classification/classification_model.py
+++ b/simpletransformers/classification/classification_model.py
@@ -306,7 +306,7 @@ class ClassificationModel:
             if self.args.n_gpu > 0:
                 torch.cuda.manual_seed_all(self.args.manual_seed)
 
-        if self.args.labels_list:
+        if self.args.labels_list and not self.args.lazy_loading:
             if num_labels:
                 assert num_labels == len(self.args.labels_list)
             if self.args.labels_map:
@@ -2303,7 +2303,7 @@ class ClassificationModel:
     def _get_inputs_dict(self, batch, no_hf=False):
         if self.args.use_hf_datasets and not no_hf:
             return {key: value.to(self.device) for key, value in batch.items()}
-        if isinstance(batch[0], dict):
+        if isinstance(batch[0], dict) or isinstance(batch[0].data, dict):
             inputs = {
                 key: value.squeeze(1).to(self.device) for key, value in batch[0].items()
             }


### PR DESCRIPTION
There seemed to be a few issues using lazy loading.  The current example didn't work, so I had to make the following changes. The first error that I would run into when trying to do lazy loading for Text Classification was:

```
Traceback (most recent call last):
  File "lazy_loading_regression.py", line 49, in <module>
    model.train_model("data/regression_train.tsv")
  File "/Users/saint/code/simpletransformers/simpletransformers/classification/classification_model.py", line 605, in train_model
    global_step, training_details = self.train(
  File "/Users/saint/code/simpletransformers/simpletransformers/classification/classification_model.py", line 877, in train
    inputs = self._get_inputs_dict(batch)
  File "/Users/saint/code/simpletransformers/simpletransformers/classification/classification_model.py", line 2318, in _get_inputs_dict
    "labels": batch[3],
IndexError: tuple index out of range
```
which was solved by the fix at [line 2306](https://github.com/ThilinaRajapakse/simpletransformers/pull/1401/commits/ad6055c69ef9136f9e830673ffa0beaaf8a2840f#diff-4d7bbc7bb36761108f409ca42195fc8cbf90feea302b257c3fcc543dc5fe335eL2306).

Furthermore, if I change the lazy_loading_regression example to make it a non regression example as shown below

```
import os

import pandas as pd

from simpletransformers.classification import ClassificationModel

train_data = [
    ["Example sentence belonging to class 1", 1],
    ["Example sentence belonging to class 0", 0],
    [
        "This is an entirely different phrase altogether and should be treated so.", 1
    ],
]

train_df = pd.DataFrame(train_data, columns=["text", "labels"])

eval_data = [
    ["Example sentence belonging to class 1", 1],
    ["Example sentence belonging to class 0", 0],
    ["Example  2 sentence belonging to class 0", 1],
]

eval_df = pd.DataFrame(eval_data, columns=["text", "labels"])

os.makedirs("data", exist_ok=True)

train_df.to_csv("data/regression_train.tsv", sep="\t", index=False)
eval_df.to_csv("data/regression_eval.tsv", sep="\t", index=False)

train_args = {
    "reprocess_input_data": True,
    "overwrite_output_dir": True,
    "lazy_header_row": True,
    "lazy_loading": True,
    "lazy_text_column": 0,
    "lazy_labels_column": 1,
    "save_steps": 1
}

# Create a TransformerModel
model = ClassificationModel("bert", "bert-base-cased", num_labels=2, args=train_args)
# print(train_df.head())

# Train the model
model.train_model("data/regression_train.tsv")

# # # Evaluate the model
result, model_outputs, wrong_predictions = model.eval_model("data/regression_eval.tsv")

print(result)

preds, out = model.predict([["Test sentence", "Other sentence"]])

print(preds)
```

Trying to resume from a checkpoint will cause the following error:

```
Traceback (most recent call last):
  File "lazy_loading_regression.py", line 51, in <module>
    result, model_outputs, wrong_predictions = model.eval_model("data/regression_eval.tsv")
  File "/Users/saint/code/simpletransformers/simpletransformers/classification/classification_model.py", line 1333, in eval_model
    result, model_outputs, wrong_preds = self.evaluate(
  File "/Users/saint/code/simpletransformers/simpletransformers/classification/classification_model.py", line 1466, in evaluate
    for i, batch in enumerate(
  File "/Users/saint/.pyenv/versions/3.8.2/lib/python3.8/site-packages/tqdm/std.py", line 1133, in __iter__
    for obj in iterable:
  File "/Users/saint/.pyenv/versions/3.8.2/lib/python3.8/site-packages/torch/utils/data/dataloader.py", line 530, in __next__
    data = self._next_data()
  File "/Users/saint/.pyenv/versions/3.8.2/lib/python3.8/site-packages/torch/utils/data/dataloader.py", line 570, in _next_data
    data = self._dataset_fetcher.fetch(index)  # may raise StopIteration
  File "/Users/saint/.pyenv/versions/3.8.2/lib/python3.8/site-packages/torch/utils/data/_utils/fetch.py", line 49, in fetch
    data = [self.dataset[idx] for idx in possibly_batched_index]
  File "/Users/saint/.pyenv/versions/3.8.2/lib/python3.8/site-packages/torch/utils/data/_utils/fetch.py", line 49, in <listcomp>
    data = [self.dataset[idx] for idx in possibly_batched_index]
  File "/Users/saint/code/simpletransformers/simpletransformers/classification/classification_utils.py", line 961, in __getitem__
    label = self.args.labels_map[label]
KeyError: '1'
```

This seem to happen only when `   "lazy_text_column": 0 ` and `"lazy_labels_column": 1` are set. The change at [line 309](https://github.com/ThilinaRajapakse/simpletransformers/pull/1401/commits/ad6055c69ef9136f9e830673ffa0beaaf8a2840f#diff-4d7bbc7bb36761108f409ca42195fc8cbf90feea302b257c3fcc543dc5fe335eL309) fixes this issue. Finally I set `lazy_loading` in the example otherwise it does not run as is.