### PR TITLE
AdamW transformers deprecation

### DIFF
--- a/simpletransformers/classification/classification_model.py
+++ b/simpletransformers/classification/classification_model.py
@@ -43,7 +43,8 @@ from transformers.optimization import (
     get_cosine_with_hard_restarts_schedule_with_warmup,
     get_polynomial_decay_schedule_with_warmup,
 )
-from transformers.optimization import AdamW, Adafactor
+from torch.optim import AdamW
+from transformers.optimization import Adafactor
 from transformers import (
     AlbertConfig,
     AlbertTokenizer,

--- a/simpletransformers/classification/multi_modal_classification_model.py
+++ b/simpletransformers/classification/multi_modal_classification_model.py
@@ -35,7 +35,8 @@ from transformers.optimization import (
     get_cosine_with_hard_restarts_schedule_with_warmup,
     get_polynomial_decay_schedule_with_warmup,
 )
-from transformers.optimization import AdamW, Adafactor
+from torch.optim import AdamW
+from transformers.optimization import Adafactor
 from transformers import (
     BERT_PRETRAINED_MODEL_ARCHIVE_LIST,
     WEIGHTS_NAME,

--- a/simpletransformers/conv_ai/conv_ai_model.py
+++ b/simpletransformers/conv_ai/conv_ai_model.py
@@ -40,7 +40,8 @@ from transformers.optimization import (
     get_cosine_with_hard_restarts_schedule_with_warmup,
     get_polynomial_decay_schedule_with_warmup,
 )
-from transformers.optimization import AdamW, Adafactor
+from torch.optim import AdamW
+from transformers.optimization import Adafactor
 from transformers import (
     WEIGHTS_NAME,
     GPT2Config,

--- a/simpletransformers/experimental/classification/classification_model.py
+++ b/simpletransformers/experimental/classification/classification_model.py
@@ -25,9 +25,9 @@ from torch.nn.utils.rnn import pad_sequence
 from torch.utils.data import DataLoader, RandomSampler, SequentialSampler, TensorDataset
 from torch.utils.data.distributed import DistributedSampler
 from tqdm.auto import tqdm, trange
+from torch.optim import AdamW
 from transformers import (
     WEIGHTS_NAME,
-    AdamW,
     AlbertConfig,
     AlbertTokenizer,
     BertConfig,

--- a/simpletransformers/language_modeling/language_modeling_model.py
+++ b/simpletransformers/language_modeling/language_modeling_model.py
@@ -42,7 +42,8 @@ from transformers.optimization import (
     get_cosine_with_hard_restarts_schedule_with_warmup,
     get_polynomial_decay_schedule_with_warmup,
 )
-from transformers.optimization import AdamW, Adafactor
+from torch.optim import AdamW
+from transformers.optimization import Adafactor
 
 from transformers import DummyObject, requires_backends
 

--- a/simpletransformers/ner/ner_model.py
+++ b/simpletransformers/ner/ner_model.py
@@ -113,7 +113,8 @@ from transformers import (
     XLNetTokenizerFast,
 )
 from transformers.convert_graph_to_onnx import convert, quantize
-from transformers.optimization import AdamW, Adafactor
+from torch.optim import AdamW
+from transformers.optimization import Adafactor
 from transformers.optimization import (
     get_constant_schedule,
     get_constant_schedule_with_warmup,

--- a/simpletransformers/question_answering/question_answering_model.py
+++ b/simpletransformers/question_answering/question_answering_model.py
@@ -31,7 +31,8 @@ from transformers.optimization import (
     get_cosine_with_hard_restarts_schedule_with_warmup,
     get_polynomial_decay_schedule_with_warmup,
 )
-from transformers.optimization import AdamW, Adafactor
+from torch.optim import AdamW
+from transformers.optimization import Adafactor
 from transformers import (
     AlbertConfig,
     AlbertForQuestionAnswering,

--- a/simpletransformers/question_answering/question_answering_utils.py
+++ b/simpletransformers/question_answering/question_answering_utils.py
@@ -24,8 +24,8 @@ from torch.utils.data import (
     TensorDataset,
 )
 from tqdm import tqdm, trange
+from torch.optim import AdamW
 from transformers import (
-    AdamW,
     SquadExample,
     XLMTokenizer,
     get_linear_schedule_with_warmup,

--- a/simpletransformers/retrieval/retrieval_model.py
+++ b/simpletransformers/retrieval/retrieval_model.py
@@ -27,7 +27,8 @@ from transformers.optimization import (
     get_cosine_with_hard_restarts_schedule_with_warmup,
     get_polynomial_decay_schedule_with_warmup,
 )
-from transformers.optimization import AdamW, Adafactor
+from torch.optim import AdamW
+from transformers.optimization import Adafactor
 from transformers.models.dpr import (
     DPRConfig,
     DPRContextEncoder,

--- a/simpletransformers/seq2seq/seq2seq_model.py
+++ b/simpletransformers/seq2seq/seq2seq_model.py
@@ -25,7 +25,8 @@ from transformers.optimization import (
     get_cosine_with_hard_restarts_schedule_with_warmup,
     get_polynomial_decay_schedule_with_warmup,
 )
-from transformers.optimization import AdamW, Adafactor
+from torch.optim import AdamW
+from transformers.optimization import Adafactor
 from transformers import (
     AutoConfig,
     AutoModel,

--- a/simpletransformers/t5/t5_model.py
+++ b/simpletransformers/t5/t5_model.py
@@ -26,7 +26,8 @@ from transformers.optimization import (
     get_cosine_with_hard_restarts_schedule_with_warmup,
     get_polynomial_decay_schedule_with_warmup,
 )
-from transformers.optimization import AdamW, Adafactor
+from torch.optim import AdamW
+from transformers.optimization import Adafactor
 from transformers.models.mt5 import MT5Config, MT5ForConditionalGeneration
 from transformers.models.byt5 import ByT5Tokenizer
 


### PR DESCRIPTION
Transformers has deprecated AdamW and issues warnings to use the torch.optim.AdamW package when called
API is the identical
I ran with NERModel