### PR TITLE
python 3.10 support

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,9 @@
 # test
 pytest-cov==2.7.1
 pytest-localserver==0.5.0
-pytest==5.1.3
+pytest==7.1.2
 
 # lint/format/types
-black==19.10b0
+black==22.3.0
 flake8==3.7.8
 pytype==2019.7.11

--- a/simpletransformers/classification/classification_utils.py
+++ b/simpletransformers/classification/classification_utils.py
@@ -22,10 +22,14 @@ import logging
 import linecache
 import os
 import sys
-import collections
 from collections import Counter
 from io import open
 from multiprocessing import Pool, cpu_count
+
+try:
+    from collections import Iterable, Mapping
+except ImportError:
+    from collections.abc import Iterable, Mapping
 
 import torch
 import torch.nn as nn
@@ -999,11 +1003,11 @@ class LazyClassificationDataset(Dataset):
 
 def flatten_results(results, parent_key="", sep="/"):
     out = []
-    if isinstance(results, collections.Mapping):
+    if isinstance(results, Mapping):
         for key, value in results.items():
             pkey = parent_key + sep + str(key) if parent_key else str(key)
             out.extend(flatten_results(value, parent_key=pkey).items())
-    elif isinstance(results, collections.Iterable):
+    elif isinstance(results, Iterable):
         for key, value in enumerate(results):
             pkey = parent_key + sep + str(key) if parent_key else str(key)
             out.extend(flatten_results(value, parent_key=pkey).items())

--- a/simpletransformers/losses/focal_loss.py
+++ b/simpletransformers/losses/focal_loss.py
@@ -1,10 +1,14 @@
 from typing import Optional, Union
-from collections import Iterable
 from numbers import Real
 import warnings
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+
+try:
+    from collections import Iterable
+except ImportError:
+    from collections.abc import Iterable
 
 # based on:
 # https://github.com/zhezh/focalloss/blob/master/focalloss.py

--- a/simpletransformers/ner/ner_utils.py
+++ b/simpletransformers/ner/ner_utils.py
@@ -17,12 +17,16 @@
 
 from __future__ import absolute_import, division, print_function
 import enum
-import collections
 import linecache
 import logging
 import os
 from io import open
 from multiprocessing import Pool, cpu_count
+
+try:
+    from collections import Iterable, Mapping
+except ImportError:
+    from collections.abc import Iterable, Mapping
 
 import pandas as pd
 import torch
@@ -753,11 +757,11 @@ class LazyNERDataset(Dataset):
 
 def flatten_results(results, parent_key="", sep="/"):
     out = []
-    if isinstance(results, collections.Mapping):
+    if isinstance(results, Mapping):
         for key, value in results.items():
             pkey = parent_key + sep + str(key) if parent_key else str(key)
             out.extend(flatten_results(value, parent_key=pkey).items())
-    elif isinstance(results, collections.Iterable):
+    elif isinstance(results, Iterable):
         for key, value in enumerate(results):
             pkey = parent_key + sep + str(key) if parent_key else str(key)
             out.extend(flatten_results(value, parent_key=pkey).items())


### PR DESCRIPTION
Suggested python 3.10 support fixes for #1426 . I have tested the fixes (using `pytest tests`) with Python **3.8.10** and **3.10.5** BUT I had to disable the `longformer-allenai/longformer-base-4096` tests because these are very memory-hungry and get killed by OOM killer on my system. So if you make use of this PR please test first.

Note: Also had to bump the versions of `pytest` and `black` in *requirements-dev.txt* in order to get these working. This is in a separate commit. Please reject this part if there is some reason to hold the versions back.