### PR TITLE
support for LLMv1 prediction for classification

### DIFF
--- a/docs/_docs/05-classification-models.md
+++ b/docs/_docs/05-classification-models.md
@@ -311,7 +311,6 @@ A metric function should take in two parameters. The first parameter will be the
 {: .notice--info}
 
 
-
 ## Evaluating a Classification Model
 
 The `eval_model()`  method is used to evaluate the model. The `eval_model()` method is identical for `ClassificationModel` and `MultiLabelClassificationModel`, except for the `multi_label` argument being `True` by default for the latter.
@@ -381,21 +380,35 @@ The `predict()`  method is used to make predictions with the model. The `predict
 
 ```python
 predictions, raw_outputs = model.predict(["Sample sentence 1", "Sample sentence 2"])
+# For LayoutLM
+predictions, raw_outputs = model.predict(
+    [
+        ["Sample page text 1", [1, 2, 3, 4], [11, 12, 13, 14], [21, 22, 23, 24], [31, 32, 33, 34]],
+        ["Sample page text 2", [1, 2, 3, 4], [11, 12, 13, 14], [21, 22, 23, 24], [31, 32, 33, 34]],
+    ]
+)
 ```
 
-**Note:** The input **must** be a List even if there is only one sentence.
+**Note:** The input **must** be a List (or list of lists) even if there is only one sentence.
 {: .notice--info}
 
 
 > *simpletransformers.classification.ClassificationModel.predict*{: .function-name}(to_predict, multi_label=False)
 
-Performs predictions on a list of text `to_predict`.
+Performs predictions on a list of text (list of lists for model types `layoutlm` and `layoutlmv2`) `to_predict`.
 {: .function-text}
 
 > Parameters
 {: .parameter-blockquote}
 
-* **to_predict** - A python list of text (str) to be sent to the model for prediction.
+* **to_predict** - A python list of text (str) to be sent to the model for prediction. For `layoutlm` and `layoutlmv2` model types, this should be a list of lists: 
+                        [
+                            [text1, [x0], [y0], [x1], [y1]],
+                            [text2, [x0], [y0], [x1], [y1]],
+                            ...
+                            [text3, [x0], [y0], [x1], [y1]]
+                        ]
+                        
 {: .parameter-list}
 
 > Returns

--- a/docs/_docs/06-classification-data-formats.md
+++ b/docs/_docs/06-classification-data-formats.md
@@ -161,7 +161,25 @@ The evaluation data format is identical to the train data format.
 | Pippin is stronger than Merry   | [1, 1] |
 
 
+#### Data format for LayoutLM models
+
+[LayoutLM](https://arxiv.org/pdf/1912.13318.pdf) model (LayoutLM: Pre-training of Text and Layout for
+Document Image Understanding) is pre-trained to consider both the text and layout information for document image understanding and information extraction tasks.
+
+Although the paper discusses using combinations of text, layout, and image features, Simple Transformers currently only supports text + layout as inputs.
+
+The data format for LayoutLM is similar to the default format described above but it also includes the bounding box information (`x0`, `y0`, `x1`, `y1`) in addition to the text. Here, `x0` and `y0` is the list of coordinates of the top-left vertices of the bounding boxes and `x1` and `y1` is the list of coordinates of the bottom-right vertices of the bounding boxes. Each list contains the list of coordinates for each word in `text`.
+
+**Note:** The bounding box coordinates must be normalized to between 0-1000 where (0,0) is the top-left corner of the image.
+{: .notice--info}
+
+| text                            | labels | x0                       | y0                       | x1                       | y1                       |
+|---------------------------------|--------|--------------------------|--------------------------|--------------------------|--------------------------|
+| Aragorn was the heir of Isildur | 1      | [10, 20, 30, 40, 50, 60] | [10, 10, 10, 10, 20, 20] | [20, 30, 40, 50, 60, 70] | [20, 20, 20, 20, 30, 40] |
+| Frodo was the heir of Isildur   | 0      | [15, 20, 30, 40, 50, 60] | [10, 10, 10, 10, 20, 20] | [20, 30, 45, 50, 60, 70] | [20, 20, 20, 20, 30, 40] |
+
 ## Prediction Data Format
+
 *Used with `predict()`*
 
 The prediction data must be a list of strings.
@@ -174,6 +192,32 @@ to_predict = [
 ```
 
 Identical for binary classification, multi-class classification, regression, and multi-label classification.
+
+### Data format for LayoutLM models
+
+The prediction data must be a list of lists. For example,
+
+```python
+to_predict = [
+    [
+        "OCR text from long page one",
+        [1, 2, 3, 4, 5, 6], # x0 values for each word
+        [11, 12, 13, 14, 15, 16], # y0 values for each word
+        [21, 22, 23, 24, 25, 26], # x1 values for each word
+        [31, 32, 33, 34, 35, 36], # y1 values for each word
+    ],
+    [
+        "OCR text from long page two",
+        [1, 2, 3, 4, 5, 6], # x0 values for each word
+        [11, 12, 13, 14, 15, 16], # y0 values for each word
+        [21, 22, 23, 24, 25, 26], # x1 values for each word
+        [31, 32, 33, 34, 35, 36], # y1 values for each word
+    ],
+]
+```
+
+Identical for binary classification, multi-class classification, regression, and multi-label classification. **Note**: The bounding box coordinates must be normalized to between 0-1000 where (0,0) is the top-left corner of the image.
+{: .notice--info}
 
 
 ## Sentence-Pair Data Format

--- a/simpletransformers/classification/classification_model.py
+++ b/simpletransformers/classification/classification_model.py
@@ -1955,7 +1955,14 @@ class ClassificationModel:
 
         Args:
             to_predict: A python list of text (str) to be sent to the model for prediction.
-
+                        For layoutlm and layoutlmv2 model types, this should be a list of lists: 
+                        [
+                            [text1, [x0], [y0], [x1], [y1]],
+                            [text2, [x0], [y0], [x1], [y1]],
+                            ...
+                            [textn, [x0], [y0], [x1], [y1]]
+                        ]
+    
         Returns:
             preds: A python list of the predictions (0 or 1) for each text.
             model_outputs: A python list of the raw model outputs for each text.
@@ -2039,10 +2046,16 @@ class ClassificationModel:
                 model = torch.nn.DataParallel(model)
 
             if isinstance(to_predict[0], list):
-                eval_examples = (
-                    *zip(*to_predict),
-                    [dummy_label for i in range(len(to_predict))],
-                )
+                if self.args.model_type in ["layoutlm", "layoutlmv2"]:
+                    eval_examples = [
+                        InputExample(i, text, None, dummy_label, x0, y0, x1, y1)
+                        for i, (text, x0, y0, x1, y1) in enumerate(to_predict)
+                    ]
+                else:
+                    eval_examples = (
+                        *zip(*to_predict),
+                        [dummy_label for i in range(len(to_predict))],
+                    )
             else:
                 eval_examples = (
                     to_predict,

--- a/simpletransformers/classification/multi_label_classification_model.py
+++ b/simpletransformers/classification/multi_label_classification_model.py
@@ -24,6 +24,8 @@ from transformers import (
     HerbertTokenizer,
     FlaubertConfig,
     FlaubertTokenizer,
+    LayoutLMConfig,
+    LayoutLMTokenizerFast,
     LongformerConfig,
     LongformerTokenizer,
     RemBertConfig,
@@ -52,6 +54,7 @@ from simpletransformers.custom_models.models import (
     DistilBertForMultiLabelSequenceClassification,
     ElectraForMultiLabelSequenceClassification,
     FlaubertForMultiLabelSequenceClassification,
+    LayoutLMForMultiLabelSequenceClassification,
     LongformerForMultiLabelSequenceClassification,
     RemBertForMultiLabelSequenceClassification,
     RobertaForMultiLabelSequenceClassification,
@@ -142,6 +145,11 @@ class MultiLabelClassificationModel(ClassificationModel):
                 FlaubertConfig,
                 FlaubertForMultiLabelSequenceClassification,
                 FlaubertTokenizer,
+            ),
+            "layoutlm": (
+                LayoutLMConfig,
+                LayoutLMForMultiLabelSequenceClassification,
+                LayoutLMTokenizerFast,
             ),
             "longformer": (
                 LongformerConfig,

--- a/simpletransformers/custom_models/models.py
+++ b/simpletransformers/custom_models/models.py
@@ -8,6 +8,8 @@ from transformers import (
     ElectraForMaskedLM,
     ElectraForPreTraining,
     FlaubertModel,
+    LayoutLMModel,
+    LayoutLMPreTrainedModel,
     LongformerModel,
     RemBertModel,
     RemBertPreTrainedModel,
@@ -86,6 +88,60 @@ class BertForMultiLabelSequenceClassification(BertPreTrainedModel):
     ):
         outputs = self.bert(
             input_ids,
+            attention_mask=attention_mask,
+            token_type_ids=token_type_ids,
+            position_ids=position_ids,
+            head_mask=head_mask,
+        )
+
+        pooled_output = outputs[1]
+
+        pooled_output = self.dropout(pooled_output)
+        logits = self.classifier(pooled_output)
+
+        outputs = (logits,) + outputs[
+            2:
+        ]  # add hidden states and attention if they are here
+
+        if labels is not None:
+            loss_fct = BCEWithLogitsLoss(pos_weight=self.pos_weight)
+            labels = labels.float()
+            loss = loss_fct(
+                logits.view(-1, self.num_labels), labels.view(-1, self.num_labels)
+            )
+            outputs = (loss,) + outputs
+
+        return outputs  # (loss), logits, (hidden_states), (attentions)
+
+
+class LayoutLMForMultiLabelSequenceClassification(LayoutLMPreTrainedModel):
+    """
+    LayoutLMv1 model adapted for multi-label sequence classification
+    """
+
+    def __init__(self, config, pos_weight=None):
+        super(LayoutLMForMultiLabelSequenceClassification, self).__init__(config)
+        self.num_labels = config.num_labels
+        self.layoutlm = LayoutLMModel(config)
+        self.dropout = nn.Dropout(config.hidden_dropout_prob)
+        self.classifier = nn.Linear(config.hidden_size, self.config.num_labels)
+        self.pos_weight = pos_weight
+
+        self.init_weights()
+
+    def forward(
+        self,
+        input_ids,
+        bbox=None,
+        attention_mask=None,
+        token_type_ids=None,
+        position_ids=None,
+        head_mask=None,
+        labels=None,
+    ):
+        outputs = self.layoutlm(
+            input_ids=input_ids,
+            bbox=bbox,
             attention_mask=attention_mask,
             token_type_ids=token_type_ids,
             position_ids=position_ids,


### PR DESCRIPTION
The `predict` method for `ClassificationModel`  as well as `MultiLabelClassificationModel` for `layoutlm` model is broken. Also improved data format documentation, specifically, for `layoutlm` model(s).  

Potential Reviewers: @ThilinaRajapakse, @whr778  