### PR TITLE
Fixes bug which prevents Marian models saved with `Seq2Seq.save_model` from being loaded

### DIFF
--- a/simpletransformers/seq2seq/seq2seq_model.py
+++ b/simpletransformers/seq2seq/seq2seq_model.py
@@ -1551,6 +1551,7 @@ class Seq2SeqModel:
                 if self.args.model_type in [
                     "bart",
                     "mbart",
+                    "marian",
                     "rag-token",
                     "rag-sequence",
                 ]:


### PR DESCRIPTION
To fix issue #1445.