### PR TITLE
Fixed non list sentence input bug in RepresentationModel encode_sentences function

### DIFF
--- a/simpletransformers/language_representation/representation_model.py
+++ b/simpletransformers/language_representation/representation_model.py
@@ -197,6 +197,9 @@ class RepresentationModel:
         else:
             embedding_func = get_all_tokens
 
+        if not isinstance(text_list, list):
+            text_list = [text_list]
+
         self.model.to(self.device)
         self.model.eval()
         batches = batch_iterable(text_list, batch_size=batch_size)


### PR DESCRIPTION
Hi,
I found a bug in line [203](https://github.com/ThilinaRajapakse/simpletransformers/blob/ce30db2260aa7b6e20c6fed8bee3ee6c6e5972be/simpletransformers/language_representation/representation_model.py#L202) and solved it.
The problem was in encode_sentences, it was taking text_list as list input. But when I provide a non-list sentence input it passes through `batch_iterable` and `batch_iterable` to do the iteration at the character level as it is expecting a list.
As a result, the output encoding returns a character-level text encoding which is wrong. And as a result the output shape of the representation also got wrong.

```py
from simpletransformers.language_representation.representation_model import RepresentationModel

model = RepresentationModel(
    'bert',
    'bert-base-uncased'
)
# wrong input text_list without list
text_encode = model.encode_sentences("I love the way live, also love the smile.")
print(text_encode.shape)
# (41, 3, 768)
```
To handle this problem, I solved it in a below way.
If someone inputs a non-list sentence then first check and make it a list of sentences.
```py
if not isinstance(text_list, list):
            text_list = [text_list]
```

Please check my solution and if everything is okay please merge it. 
Thanks and regards