### PR TITLE
Fix wandb deprecated plots

### DIFF
--- a/simpletransformers/classification/classification_model.py
+++ b/simpletransformers/classification/classification_model.py
@@ -1644,13 +1644,7 @@ class ClassificationModel:
                 wandb.log({"roc": wandb.plot.roc_curve(truth, model_outputs, labels_list)})
 
                 # Precision Recall
-                wandb.log(
-                    {
-                        "pr": wandb.plot.pr_curve(
-                            truth, model_outputs, labels_list
-                        )
-                    }
-                )
+                wandb.log({"pr": wandb.plot.pr_curve(truth, model_outputs, labels_list)})
 
         return results, model_outputs, wrong
 

--- a/simpletransformers/classification/classification_model.py
+++ b/simpletransformers/classification/classification_model.py
@@ -1641,12 +1641,12 @@ class ClassificationModel:
 
             if not self.args.sliding_window:
                 # ROC`
-                wandb.log({"roc": wandb.plots.ROC(truth, model_outputs, labels_list)})
+                wandb.log({"roc": wandb.plot.roc_curve(truth, model_outputs, labels_list)})
 
                 # Precision Recall
                 wandb.log(
                     {
-                        "pr": wandb.plots.precision_recall(
+                        "pr": wandb.plot.pr_curve(
                             truth, model_outputs, labels_list
                         )
                     }

--- a/simpletransformers/ner/ner_model.py
+++ b/simpletransformers/ner/ner_model.py
@@ -1403,10 +1403,10 @@ class NERModel:
             ]
 
             # ROC
-            wandb.log({"roc": wandb.plots.ROC(truth, outputs, labels_list)})
+            wandb.log({"roc": wandb.plot.roc_curve(truth, outputs, labels_list)})
 
             # Precision Recall
-            wandb.log({"pr": wandb.plots.precision_recall(truth, outputs, labels_list)})
+            wandb.log({"pr": wandb.plot.pr_curve(truth, outputs, labels_list)})
 
             # Confusion Matrix
             wandb.sklearn.plot_confusion_matrix(


### PR DESCRIPTION
Suggested fix for old unresolved issue #1135 . Ensures continued compatibility with next major version of wandb.

Tested with wandb **0.10.32** (minimum version required in *setup.py*) and **0.13.4** (latest). Works for both.