### PR TITLE
docs: correct typo in model_name description

### DIFF
--- a/simpletransformers/classification/multi_label_classification_model.py
+++ b/simpletransformers/classification/multi_label_classification_model.py
@@ -95,7 +95,7 @@ class MultiLabelClassificationModel(ClassificationModel):
 
         Args:
             model_type: The type of model (bert, roberta)
-            model_name: Default Transformer model name or path to a directory containing Transformer model file (pytorch_nodel.bin).
+            model_name: Default Transformer model name or path to a directory containing Transformer model file (pytorch_model.bin).
             num_labels (optional): The number of labels or classes in the dataset.
             pos_weight (optional): A list of length num_labels containing the weights to assign to each label for loss calculation.
             args (optional): Default args will be used if this parameter is not provided. If provided, it should be a dict containing the args that should be changed in the default args.

--- a/simpletransformers/classification/multi_modal_classification_model.py
+++ b/simpletransformers/classification/multi_modal_classification_model.py
@@ -92,7 +92,7 @@ class MultiModalClassificationModel:
 
         Args:
             model_type: The type of model (bert, xlnet, xlm, roberta, distilbert, albert)
-            model_name: Default Transformer model name or path to a directory containing Transformer model file (pytorch_nodel.bin).
+            model_name: Default Transformer model name or path to a directory containing Transformer model file (pytorch_model.bin).
             multi_label (optional): Set to True for multi label tasks.
             label_list (optional) : A list of all the labels (str) in the dataset.
             num_labels (optional): The number of labels or classes in the dataset.

--- a/simpletransformers/conv_ai/conv_ai_model.py
+++ b/simpletransformers/conv_ai/conv_ai_model.py
@@ -101,7 +101,7 @@ class ConvAIModel:
 
         Args:
             model_type: The type of model (gpt, gpt2)
-            model_name: Default Transformer model name or path to a directory containing Transformer model file (pytorch_nodel.bin).
+            model_name: Default Transformer model name or path to a directory containing Transformer model file (pytorch_model.bin).
             args (optional): Default args will be used if this parameter is not provided. If provided, it should be a dict containing the args that should be changed in the default args.
             use_cuda (optional): Use GPU if available. Setting to False will force model to use CPU only.
             cuda_device (optional): Specific GPU that should be used. Will use the first available GPU by default.

--- a/simpletransformers/experimental/classification/classification_model.py
+++ b/simpletransformers/experimental/classification/classification_model.py
@@ -88,7 +88,7 @@ class ClassificationModel:
 
         Args:
             model_type: The type of model (bert, xlnet, xlm, roberta, distilbert, albert, camembert)
-            model_name: Default Transformer model name or path to a directory containing Transformer model file (pytorch_nodel.bin).
+            model_name: Default Transformer model name or path to a directory containing Transformer model file (pytorch_model.bin).
             num_labels (optional): The number of labels or classes in the dataset.
             weight (optional): A list of length num_labels containing the weights to assign to each label for loss calculation.
             sliding_window (optional): Use a sliding window when tokenizing to prevent truncating long sequences. Default = False.

--- a/simpletransformers/experimental/classification/multi_label_classification_model.py
+++ b/simpletransformers/experimental/classification/multi_label_classification_model.py
@@ -43,7 +43,7 @@ class MultiLabelClassificationModel(ClassificationModel):
 
         Args:
             model_type: The type of model (bert, roberta)
-            model_name: Default Transformer model name or path to a directory containing Transformer model file (pytorch_nodel.bin).
+            model_name: Default Transformer model name or path to a directory containing Transformer model file (pytorch_model.bin).
             num_labels (optional): The number of labels or classes in the dataset.
             pos_weight (optional): A list of length num_labels containing the weights to assign to each label for loss calculation.
             args (optional): Default args will be used if this parameter is not provided. If provided, it should be a dict containing the args that should be changed in the default args.

--- a/simpletransformers/language_generation/language_generation_model.py
+++ b/simpletransformers/language_generation/language_generation_model.py
@@ -55,7 +55,7 @@ class LanguageGenerationModel:
 
         Args:
             model_type: The type of model (gpt2, ctrl, openai-gpt, xlnet, transfo-xl, xlm)
-            model_name: Default Transformer model name or path to a directory containing Transformer model file (pytorch_nodel.bin).
+            model_name: Default Transformer model name or path to a directory containing Transformer model file (pytorch_model.bin).
             args (optional): Default args will be used if this parameter is not provided. If provided, it should be a dict containing the args that should be changed in the default args.
             use_cuda (optional): Use GPU if available. Setting to False will force model to use CPU only.
             cuda_device (optional): Specific GPU that should be used. Will use the first available GPU by default.

--- a/simpletransformers/language_modeling/language_modeling_model.py
+++ b/simpletransformers/language_modeling/language_modeling_model.py
@@ -160,7 +160,7 @@ class LanguageModelingModel:
 
         Args:
             model_type: The type of model (gpt2, openai-gpt, bert, roberta, distilbert, camembert)
-            model_name: Default Transformer model name or path to a directory containing Transformer model file (pytorch_nodel.bin).
+            model_name: Default Transformer model name or path to a directory containing Transformer model file (pytorch_model.bin).
             generator_name (optional): A pretrained model name or path to a directory containing an ELECTRA generator model.
             discriminator_name (optional): A pretrained model name or path to a directory containing an ELECTRA discriminator model.
             args (optional): Default args will be used if this parameter is not provided. If provided, it should be a dict containing the args that should be changed in the default args.

--- a/simpletransformers/question_answering/question_answering_model.py
+++ b/simpletransformers/question_answering/question_answering_model.py
@@ -124,7 +124,7 @@ class QuestionAnsweringModel:
 
         Args:
             model_type: The type of model (bert, xlnet, xlm, distilbert)
-            model_name: Default Transformer model name or path to a directory containing Transformer model file (pytorch_nodel.bin).
+            model_name: Default Transformer model name or path to a directory containing Transformer model file (pytorch_model.bin).
             args (optional): Default args will be used if this parameter is not provided. If provided,
                 it should be a dict containing the args that should be changed in the default args'
             use_cuda (optional): Use GPU if available. Setting to False will force model to use CPU only.


### PR DESCRIPTION
correct typo in model_name description(pytorch_nodel.bin→pytorch_model.bin)