### PR TITLE
There is a bug in the `get_examples_from_df` module 

### DIFF
--- a/simpletransformers/ner/ner_utils.py
+++ b/simpletransformers/ner/ner_utils.py
@@ -173,6 +173,7 @@ def read_examples_from_file(data_file, mode, bbox=False):
 
 
 def get_examples_from_df(data, bbox=False):
+    data = pd.DataFrame(data,columns=["sentence_id","words","labels"])
     if bbox:
         return [
             InputExample(


### PR DESCRIPTION
The `get_examples_from_df` requires a pandas dataframe and not a list.