### PR TITLE
Record the vocab size in the LanguageModelingModel args

### DIFF
--- a/simpletransformers/language_modeling/language_modeling_model.py
+++ b/simpletransformers/language_modeling/language_modeling_model.py
@@ -391,6 +391,7 @@ class LanguageModelingModel:
                     self.model.module if hasattr(self.model, "module") else self.model
                 )
                 model_to_resize.resize_token_embeddings(len(self.tokenizer))
+                self.args.vocab_size = len(self.tokenizer)
 
         if model_type in ["camembert", "xlmroberta"]:
             warnings.warn(


### PR DESCRIPTION
This needs to be set in the args so that it is correctly stored when they are saved to disk, otherwise the model can't be successfully loaded later.

This fixes #1527 