### PR TITLE
Add umT5 support to T5Model.

### DIFF
--- a/docs/_docs/24-t5-specifics.md
+++ b/docs/_docs/24-t5-specifics.md
@@ -43,11 +43,12 @@ Using a T5 Model in Simple Transformers follows the [standard pattern](/docs/usa
 
 ## Supported Model Types
 
-| Model | Model code for `NERModel` |
-| ----- | ------------------------- |
-| T5    | t5                        |
-| MT5   | mt5                       |
-| ByT5  | byt5                      |
+| Model | Model code for `T5Model` |
+|-------|--------------------------|
+| T5    | t5                       |
+| MT5   | mt5                      |
+| ByT5  | byt5                     |
+| umT5  | umt5                     |
 
 **Tip:** The model code is used to specify the `model_type` in a Simple Transformers model.
 {: .notice--success}

--- a/simpletransformers/t5/t5_model.py
+++ b/simpletransformers/t5/t5_model.py
@@ -30,6 +30,7 @@ from torch.optim import AdamW
 from transformers.optimization import Adafactor
 from transformers.models.mt5 import MT5Config, MT5ForConditionalGeneration
 from transformers.models.byt5 import ByT5Tokenizer
+from transformers.models.umt5 import UMT5Config, UMT5ForConditionalGeneration
 
 from simpletransformers.config.global_args import global_args
 from simpletransformers.config.model_args import T5Args
@@ -56,9 +57,10 @@ MODEL_CLASSES = {
     "t5": (T5Config, T5ForConditionalGeneration),
     "mt5": (MT5Config, MT5ForConditionalGeneration),
     "byt5": (T5Config, T5ForConditionalGeneration),
+    "umt5": (UMT5Config, UMT5ForConditionalGeneration),
 }
 
-
+b
 class T5Model:
     def __init__(
         self,
@@ -75,7 +77,7 @@ class T5Model:
         Initializes a T5Model model.
 
         Args:
-            model_type: The type of model (t5, mt5, byt5)
+            model_type: The type of model (t5, mt5, byt5, umt5)
             model_name: The exact architecture and trained weights to use. This may be a Hugging Face Transformers compatible pre-trained model, a community model, or the path to a directory containing model files.
             args (optional): Default args will be used if this parameter is not provided. If provided, it should be a dict containing the args that should be changed in the default args.
             use_cuda (optional): Use GPU if available. Setting to False will force model to use CPU only.


### PR DESCRIPTION
I tried to use google/umT5-base with T5 but got horrible performance. Then I saw `transformers` had a separate umT5 class, which I added to the model classes dict in this commit. 