### PR TITLE
fix evaluation during training for t5

### DIFF
--- a/tests/test_t5.py
+++ b/tests/test_t5.py
@@ -30,13 +30,15 @@ def test_t5():
         "save_model_every_epoch": False,
         "max_length": 20,
         "num_beams": 1,
+        "evaluate_generated_text": True,
+        "evaluate_during_training": True,
     }
 
     # Create T5 Model
     model = T5Model("t5", "t5-base", args=model_args, use_cuda=False)
 
     # Train T5 Model on new task
-    model.train_model(train_df)
+    model.train_model(train_df, eval_data=eval_data)
 
     # Evaluate T5 Model on new task
     model.eval_model(eval_df)


### PR DESCRIPTION
This fixes #1524: When evaluating a T5 model during training a TypeError is thrown. 

This was because the eval_model method tried to get the inputs for the evaluation from the wrong dataset. *I think* `eval_dataset` contains the encoded inputs (and does not have column names) - the fix was just replacing the reference to `eval_dataset` with `eval_data` which is the dataframe that eval_data gets from the arguments to the `train_model` method. 

There might be some superfluous work here as the model feeds the inputs through the model twice instead of just doing additional processing of the outputs of `T5model.evaluate()` - but my solution works as a hotfix.