### PR TITLE
fixed multiprocessing issue during RoBERTa prediction - Solution to #1558

### DIFF
--- a/simpletransformers/classification/classification_model.py
+++ b/simpletransformers/classification/classification_model.py
@@ -484,10 +484,11 @@ class ClassificationModel:
 
         if model_type in ["camembert", "xlmroberta"]:
             warnings.warn(
-                f"use_multiprocessing automatically disabled as {model_type}"
+                f"use_multiprocessing and use_multiprocessing_for_evaluation automatically disabled as {model_type}"
                 " fails when using multiprocessing for feature conversion."
             )
             self.args.use_multiprocessing = False
+            self.args.use_multiprocessing_for_evaluation = False
 
         if self.args.wandb_project and not wandb_available:
             warnings.warn(


### PR DESCRIPTION
With reference to #1558 
When using a RoBERTa model for doing prediction, when the model is loaded using `ClassificationModel()` it prompts a warning stating,

> UserWarning: use_multiprocessing automatically disabled as xlmroberta fails when using multiprocessing for feature conversion.

When prediction is performed on text data, if the number of records are a little more than a handful, the prediction progress bar takes infinite execution. 

The issue occurs because in the `classification_model.py` file under the `ClassificationModel` class, there are two arguments that concern with multiprocessing, them being, `args.use_multiprocessing` and `args.use_multiprocessing_for_evaluation`. While one is set to False by default, the other remains to be True,as can be seen in the screenshot attached:


<img width="1093" alt="image" src="https://github.com/ThilinaRajapakse/simpletransformers/assets/36883390/32980c9b-f373-4915-94b8-b92c2c0b67d9">

<br><br>
To be able to perform prediction by successfully disabling multiprocessing, we need to disable `args.use_multiprocessing_for_evaluation = False` and it should work fine. The approach has been tested locally and has proven to be working. Screenshot attached:


<img width="1066" alt="working" src="https://github.com/ThilinaRajapakse/simpletransformers/assets/36883390/575a6305-38bd-47bb-86dd-f97ac4af93a5">


